### PR TITLE
Fix the redifinition of supported providers

### DIFF
--- a/src/include/flockmtl/secret_manager/secret_manager.hpp
+++ b/src/include/flockmtl/secret_manager/secret_manager.hpp
@@ -21,8 +21,11 @@ extern const SecretDetails ollama_secret_details;
 
 class SecretManager {
 public:
+    enum SupportedProviders { OPENAI, AZURE, OLLAMA };
+
     static void Register(duckdb::DatabaseInstance& instance);
     static std::unordered_map<std::string, std::string> GetSecret(std::string provider);
+    static SupportedProviders GetProviderType(std::string provider);
 
 private:
     static void RegisterSecretType(duckdb::DatabaseInstance& instance);

--- a/src/secret_manager/secret_manager.cpp
+++ b/src/secret_manager/secret_manager.cpp
@@ -17,9 +17,7 @@ const SecretDetails ollama_secret_details = {"ollama", "flockmtl", "ollama://", 
 const std::vector<const SecretDetails*> secret_details_list = {&openai_secret_details, &azure_secret_details,
                                                                &ollama_secret_details};
 
-enum SupportedProviders { OPENAI, AZURE, OLLAMA };
-
-SupportedProviders GetProviderType(std::string provider) {
+SecretManager::SupportedProviders SecretManager::GetProviderType(std::string provider) {
     if (provider == "openai") {
         return OPENAI;
     } else if (provider == "azure") {
@@ -113,7 +111,7 @@ std::unordered_map<std::string, std::string> SecretManager::GetSecret(std::strin
     const auto kv_secret = dynamic_cast<const duckdb::KeyValueSecret&>(*secret->secret);
 
     auto provider = secret->secret->GetType();
-    auto providerType = GetProviderType(provider);
+    auto providerType = SecretManager::GetProviderType(provider);
     SecretDetails secret_details;
     switch (providerType) {
     case SupportedProviders::OPENAI:


### PR DESCRIPTION
This PR moved the supported providers enum under SecretManager to avoid the redefinition with the ModelManager. The supported providers could be different if the provider doesn't need a secret.