### PR TITLE
Openai compatible providers

### DIFF
--- a/.github/workflows/WebsiteDeploy.yaml
+++ b/.github/workflows/WebsiteDeploy.yaml
@@ -32,7 +32,7 @@ jobs:
         working-directory: docs
 
       - name: Upload Build Artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: docs/build
 

--- a/notebooks/disaster_tweet_flockmtl.py
+++ b/notebooks/disaster_tweet_flockmtl.py
@@ -41,11 +41,11 @@ api.dataset_download_files(
 
 # %%
 # Initialize DuckDB
-con = duckdb.connect(':memory:', config={'allow_unsigned_extensions': 'true'})
+con = duckdb.connect(':memory:')
 
 # Load FlockMTL extension
-con.sql("LOAD flockmtl FROM community")
-con.sql("INSTALL flockmtl")
+con.sql("INSTALL flockmtl FROM community")
+con.sql("LOAD flockmtl")
 
 # %% [markdown]
 # ## Step 4: Load and Preview Dataset

--- a/notebooks/product_review_analysis_flockmtl.py
+++ b/notebooks/product_review_analysis_flockmtl.py
@@ -52,15 +52,15 @@ api.dataset_download_files(
 # We create an in-memory DuckDB database for this analysis.
 
 # %%
-con = duckdb.connect(':memory:', config={'allow_unsigned_extensions': 'true'})
+con = duckdb.connect(':memory:')
 
 # %% [markdown]
 # ## Step 4: Load and Install FlockMTL Extension
 # The FlockMTL extension enables advanced natural language processing with LLMs.
 
 # %%
-con.sql("LOAD flockmtl FROM community")
-con.sql("INSTALL flockmtl")
+con.sql("INSTALL flockmtl FROM community")
+con.sql("LOAD flockmtl")
 
 # %% [markdown]
 # ## Step 5: Configure OpenAI Secret

--- a/src/model_manager/providers/adapters/openai.cpp
+++ b/src/model_manager/providers/adapters/openai.cpp
@@ -3,7 +3,11 @@
 namespace flockmtl {
 
 nlohmann::json OpenAIProvider::CallComplete(const std::string& prompt, bool json_response) {
-    openai::start(model_details_.secret["api_key"]);
+    auto base_url = std::string("");
+    if (const auto it = model_details_.secret.find("base_url"); it != model_details_.secret.end()) {
+        base_url = it->second;
+    }
+    auto openai = openai::OpenAI(model_details_.secret["api_key"], "", true, base_url);
 
     // Create a JSON request payload with the provided parameters
     nlohmann::json request_payload = {{"model", model_details_.model},
@@ -19,7 +23,7 @@ nlohmann::json OpenAIProvider::CallComplete(const std::string& prompt, bool json
     // Make a request to the OpenAI API
     nlohmann::json completion;
     try {
-        completion = openai::chat().create(request_payload);
+        completion = openai.chat.create(request_payload);
     } catch (const std::exception& e) {
         throw std::runtime_error("Error in making request to OpenAI API: " + std::string(e.what()));
     }
@@ -53,7 +57,11 @@ nlohmann::json OpenAIProvider::CallComplete(const std::string& prompt, bool json
 }
 
 nlohmann::json OpenAIProvider::CallEmbedding(const std::vector<std::string>& inputs) {
-    openai::start(model_details_.secret["api_key"]);
+    auto base_url = std::string("");
+    if (const auto it = model_details_.secret.find("base_url"); it != model_details_.secret.end()) {
+        base_url = it->second;
+    }
+    auto openai = openai::OpenAI(model_details_.secret["api_key"], "", true, base_url);
 
     // Create a JSON request payload with the provided parameters
     nlohmann::json request_payload = {
@@ -62,7 +70,7 @@ nlohmann::json OpenAIProvider::CallEmbedding(const std::vector<std::string>& inp
     };
 
     // Make a request to the OpenAI API
-    auto completion = openai::embedding().create(request_payload);
+    auto completion = openai.embedding.create(request_payload);
 
     // Check if the conversation was too long for the context window
     if (completion["choices"][0]["finish_reason"] == "length") {

--- a/src/secret_manager/secret_manager.cpp
+++ b/src/secret_manager/secret_manager.cpp
@@ -6,7 +6,8 @@
 
 namespace flockmtl {
 
-const SecretDetails openai_secret_details = {"openai", "flockmtl", "openai://", {"api_key"}, {"api_key"}, {"api_key"}};
+const SecretDetails openai_secret_details = {"openai",    "flockmtl", "openai://", {"base_url", "api_key"},
+                                             {"api_key"}, {"api_key"}};
 
 const SecretDetails azure_secret_details = {"azure_llm",    "flockmtl",
                                             "azure_llm://", {"api_key", "resource_name", "api_version"},
@@ -123,7 +124,10 @@ std::unordered_map<std::string, std::string> SecretManager::GetSecret(std::strin
     }
 
     for (auto field : secret_details.fields) {
-        secret_map[field] = kv_secret.TryGetValue(field).ToString();
+        auto value = kv_secret.TryGetValue(field);
+        if (!value.IsNull()) {
+            secret_map[field] = value.ToString();
+        }
     }
 
     return secret_map;


### PR DESCRIPTION
This PR makes Flockmtl support providers with an OpenAI compatible API, so you can now create your secret by providing `base_url`.

```
CREATE SECRET (
     API_KEY 'your-api-key'
)
```
or
```
CREATE SECRET (
     BASE_URL 'your-provider-url',
     API_KEY 'your-api-key'
)
```