### PR TITLE
Implements RAII-based storage attachment guard with retry logic

### DIFF
--- a/src/custom_parser/query/model_parser.cpp
+++ b/src/custom_parser/query/model_parser.cpp
@@ -2,6 +2,7 @@
 
 #include "flock/core/common.hpp"
 #include "flock/core/config.hpp"
+#include "flock/custom_parser/query_parser.hpp"
 #include <sstream>
 #include <stdexcept>
 
@@ -303,101 +304,120 @@ std::string ModelParser::ToSQL(const QueryStatement& statement) const {
     switch (statement.type) {
         case StatementType::CREATE_MODEL: {
             const auto& create_stmt = static_cast<const CreateModelStatement&>(statement);
-            auto con = Config::GetConnection();
-            auto result = con.Query(duckdb_fmt::format(
-                    " SELECT model_name"
-                    "  FROM flock_storage.flock_config.FLOCKMTL_MODEL_DEFAULT_INTERNAL_TABLE"
-                    " WHERE model_name = '{}'"
-                    " UNION ALL "
-                    " SELECT model_name "
-                    "   FROM {}flock_config.FLOCKMTL_MODEL_USER_DEFINED_INTERNAL_TABLE"
-                    "  WHERE model_name = '{}';",
-                    create_stmt.model_name, create_stmt.catalog.empty() ? "flock_storage." : "", create_stmt.model_name));
-            if (result->RowCount() != 0) {
-                throw std::runtime_error(duckdb_fmt::format("Model '{}' already exist.", create_stmt.model_name));
-            }
+            query = ExecuteQueryWithStorage([&create_stmt](duckdb::Connection& con) {
+                // Check if model already exists
+                auto result = con.Query(duckdb_fmt::format(
+                        " SELECT model_name"
+                        "  FROM flock_storage.flock_config.FLOCKMTL_MODEL_DEFAULT_INTERNAL_TABLE"
+                        " WHERE model_name = '{}'"
+                        " UNION ALL "
+                        " SELECT model_name "
+                        "   FROM {}flock_config.FLOCKMTL_MODEL_USER_DEFINED_INTERNAL_TABLE"
+                        "  WHERE model_name = '{}';",
+                        create_stmt.model_name, create_stmt.catalog.empty() ? "flock_storage." : "", create_stmt.model_name));
 
-            query = duckdb_fmt::format(" INSERT INTO "
-                                       " {}flock_config.FLOCKMTL_MODEL_USER_DEFINED_INTERNAL_TABLE "
-                                       " (model_name, model, provider_name, model_args) "
-                                       " VALUES ('{}', '{}', '{}', '{}');",
-                                       create_stmt.catalog, create_stmt.model_name, create_stmt.model,
-                                       create_stmt.provider_name, create_stmt.model_args.dump());
+                auto& materialized_result = result->Cast<duckdb::MaterializedQueryResult>();
+                if (materialized_result.RowCount() != 0) {
+                    throw std::runtime_error(duckdb_fmt::format("Model '{}' already exist.", create_stmt.model_name));
+                }
+
+                // Insert the new model
+                auto insert_query = duckdb_fmt::format(" INSERT INTO "
+                                                       " {}flock_config.FLOCKMTL_MODEL_USER_DEFINED_INTERNAL_TABLE "
+                                                       " (model_name, model, provider_name, model_args) "
+                                                       " VALUES ('{}', '{}', '{}', '{}');",
+                                                       create_stmt.catalog, create_stmt.model_name, create_stmt.model,
+                                                       create_stmt.provider_name, create_stmt.model_args.dump());
+                con.Query(insert_query);
+
+                return std::string("SELECT 'Model created successfully' AS status");
+            },
+                                            false);
             break;
         }
         case StatementType::DELETE_MODEL: {
             const auto& delete_stmt = static_cast<const DeleteModelStatement&>(statement);
-            auto con = Config::GetConnection();
-
-            con.Query(duckdb_fmt::format(" DELETE FROM flock_config.FLOCKMTL_MODEL_USER_DEFINED_INTERNAL_TABLE "
-                                         "  WHERE model_name = '{}';",
-                                         delete_stmt.model_name));
-
-            query = duckdb_fmt::format(" DELETE FROM "
+            query = ExecuteSetQuery(
+                    duckdb_fmt::format(" DELETE FROM flock_config.FLOCKMTL_MODEL_USER_DEFINED_INTERNAL_TABLE "
+                                       "  WHERE model_name = '{}'; "
+                                       " DELETE FROM "
                                        " flock_storage.flock_config.FLOCKMTL_MODEL_USER_DEFINED_INTERNAL_TABLE "
                                        "  WHERE model_name = '{}';",
-                                       delete_stmt.model_name, delete_stmt.model_name);
+                                       delete_stmt.model_name, delete_stmt.model_name),
+                    "Model deleted successfully",
+                    false);
             break;
         }
         case StatementType::UPDATE_MODEL: {
             const auto& update_stmt = static_cast<const UpdateModelStatement&>(statement);
-            auto con = Config::GetConnection();
-            // get the location of the model_name if local or global
-            auto result = con.Query(
-                    duckdb_fmt::format(" SELECT model_name, 'global' AS scope "
-                                       "   FROM flock_storage.flock_config.FLOCKMTL_MODEL_USER_DEFINED_INTERNAL_TABLE"
-                                       "  WHERE model_name = '{}'"
-                                       " UNION ALL "
-                                       " SELECT model_name, 'local' AS scope "
-                                       "   FROM flock_config.FLOCKMTL_MODEL_USER_DEFINED_INTERNAL_TABLE"
-                                       "  WHERE model_name = '{}';",
-                                       update_stmt.model_name, update_stmt.model_name, update_stmt.model_name));
+            query = ExecuteQueryWithStorage([&update_stmt](duckdb::Connection& con) {
+                // Get the location of the model_name if local or global
+                auto result = con.Query(
+                        duckdb_fmt::format(" SELECT model_name, 'global' AS scope "
+                                           "   FROM flock_storage.flock_config.FLOCKMTL_MODEL_USER_DEFINED_INTERNAL_TABLE"
+                                           "  WHERE model_name = '{}'"
+                                           " UNION ALL "
+                                           " SELECT model_name, 'local' AS scope "
+                                           "   FROM flock_config.FLOCKMTL_MODEL_USER_DEFINED_INTERNAL_TABLE"
+                                           "  WHERE model_name = '{}';",
+                                           update_stmt.model_name, update_stmt.model_name, update_stmt.model_name));
 
-            if (result->RowCount() == 0) {
-                throw std::runtime_error(duckdb_fmt::format("Model '{}' doesn't exist.", update_stmt.model_name));
-            }
+                auto& materialized_result = result->Cast<duckdb::MaterializedQueryResult>();
+                if (materialized_result.RowCount() == 0) {
+                    throw std::runtime_error(duckdb_fmt::format("Model '{}' doesn't exist.", update_stmt.model_name));
+                }
 
-            auto catalog = result->GetValue(1, 0).ToString() == "global" ? "flock_storage." : "";
+                auto catalog = materialized_result.GetValue(1, 0).ToString() == "global" ? "flock_storage." : "";
 
-            query = duckdb_fmt::format(" UPDATE {}flock_config.FLOCKMTL_MODEL_USER_DEFINED_INTERNAL_TABLE "
-                                       "    SET model = '{}', provider_name = '{}', "
-                                       " model_args = '{}' WHERE model_name = '{}'; ",
-                                       catalog, update_stmt.new_model, update_stmt.provider_name,
-                                       update_stmt.new_model_args.dump(), update_stmt.model_name);
+                con.Query(duckdb_fmt::format(" UPDATE {}flock_config.FLOCKMTL_MODEL_USER_DEFINED_INTERNAL_TABLE "
+                                             "    SET model = '{}', provider_name = '{}', "
+                                             " model_args = '{}' WHERE model_name = '{}'; ",
+                                             catalog, update_stmt.new_model, update_stmt.provider_name,
+                                             update_stmt.new_model_args.dump(), update_stmt.model_name));
+
+                return std::string("SELECT 'Model updated successfully' AS status");
+            },
+                                            false);
             break;
         }
         case StatementType::UPDATE_MODEL_SCOPE: {
             const auto& update_stmt = static_cast<const UpdateModelScopeStatement&>(statement);
-            auto con = Config::GetConnection();
-            auto result =
-                    con.Query(duckdb_fmt::format(" SELECT model_name "
-                                                 "   FROM {}flock_config.FLOCKMTL_MODEL_USER_DEFINED_INTERNAL_TABLE"
-                                                 "  WHERE model_name = '{}';",
-                                                 update_stmt.catalog, update_stmt.model_name));
-            if (result->RowCount() != 0) {
-                throw std::runtime_error(
-                        duckdb_fmt::format("Model '{}' already exist in {} storage.", update_stmt.model_name,
-                                           update_stmt.catalog == "flock_storage." ? "global" : "local"));
-            }
+            query = ExecuteQueryWithStorage([&update_stmt](duckdb::Connection& con) {
+                auto result = con.Query(duckdb_fmt::format(" SELECT model_name "
+                                                           "   FROM {}flock_config.FLOCKMTL_MODEL_USER_DEFINED_INTERNAL_TABLE"
+                                                           "  WHERE model_name = '{}';",
+                                                           update_stmt.catalog, update_stmt.model_name));
 
-            con.Query(duckdb_fmt::format("INSERT INTO {}flock_config.FLOCKMTL_MODEL_USER_DEFINED_INTERNAL_TABLE "
-                                         "(model_name, model, provider_name, model_args) "
-                                         "SELECT model_name, model, provider_name, model_args "
-                                         "FROM {}flock_config.FLOCKMTL_MODEL_USER_DEFINED_INTERNAL_TABLE "
-                                         "WHERE model_name = '{}'; ",
-                                         update_stmt.catalog,
-                                         update_stmt.catalog == "flock_storage." ? "" : "flock_storage.",
-                                         update_stmt.model_name));
+                auto& materialized_result = result->Cast<duckdb::MaterializedQueryResult>();
+                if (materialized_result.RowCount() != 0) {
+                    throw std::runtime_error(
+                            duckdb_fmt::format("Model '{}' already exist in {} storage.", update_stmt.model_name,
+                                               update_stmt.catalog == "flock_storage." ? "global" : "local"));
+                }
 
-            query = duckdb_fmt::format("DELETE FROM {}flock_config.FLOCKMTL_MODEL_USER_DEFINED_INTERNAL_TABLE "
-                                       "WHERE model_name = '{}'; ",
-                                       update_stmt.catalog == "flock_storage." ? "" : "flock_storage.",
-                                       update_stmt.model_name);
+                con.Query(duckdb_fmt::format("INSERT INTO {}flock_config.FLOCKMTL_MODEL_USER_DEFINED_INTERNAL_TABLE "
+                                             "(model_name, model, provider_name, model_args) "
+                                             "SELECT model_name, model, provider_name, model_args "
+                                             "FROM {}flock_config.FLOCKMTL_MODEL_USER_DEFINED_INTERNAL_TABLE "
+                                             "WHERE model_name = '{}'; ",
+                                             update_stmt.catalog,
+                                             update_stmt.catalog == "flock_storage." ? "" : "flock_storage.",
+                                             update_stmt.model_name));
+
+                con.Query(duckdb_fmt::format("DELETE FROM {}flock_config.FLOCKMTL_MODEL_USER_DEFINED_INTERNAL_TABLE "
+                                             "WHERE model_name = '{}'; ",
+                                             update_stmt.catalog == "flock_storage." ? "" : "flock_storage.",
+                                             update_stmt.model_name));
+
+                return std::string("SELECT 'Model scope updated successfully' AS status");
+            },
+                                            false);
             break;
         }
         case StatementType::GET_MODEL: {
             const auto& get_stmt = static_cast<const GetModelStatement&>(statement);
-            query = duckdb_fmt::format("SELECT 'global' AS scope, * "
+            query = ExecuteGetQuery(
+                    duckdb_fmt::format("SELECT 'global' AS scope, * "
                                        "FROM flock_storage.flock_config.FLOCKMTL_MODEL_DEFAULT_INTERNAL_TABLE "
                                        "WHERE model_name = '{}' "
                                        "UNION ALL "
@@ -408,20 +428,22 @@ std::string ModelParser::ToSQL(const QueryStatement& statement) const {
                                        "SELECT 'local' AS scope, * "
                                        "FROM flock_config.FLOCKMTL_MODEL_USER_DEFINED_INTERNAL_TABLE "
                                        "WHERE model_name = '{}';",
-                                       get_stmt.model_name, get_stmt.model_name, get_stmt.model_name, get_stmt.model_name);
+                                       get_stmt.model_name, get_stmt.model_name, get_stmt.model_name, get_stmt.model_name),
+                    true);
             break;
         }
 
         case StatementType::GET_ALL_MODEL: {
-            query = duckdb_fmt::format(" SELECT 'global' AS scope, * "
-                                       " FROM flock_storage.flock_config.FLOCKMTL_MODEL_DEFAULT_INTERNAL_TABLE"
-                                       " UNION ALL "
-                                       " SELECT 'global' AS scope, * "
-                                       " FROM flock_storage.flock_config.FLOCKMTL_MODEL_USER_DEFINED_INTERNAL_TABLE"
-                                       " UNION ALL "
-                                       " SELECT 'local' AS scope, * "
-                                       " FROM flock_config.FLOCKMTL_MODEL_USER_DEFINED_INTERNAL_TABLE;",
-                                       Config::get_global_storage_path().string());
+            query = ExecuteGetQuery(
+                    " SELECT 'global' AS scope, * "
+                    " FROM flock_storage.flock_config.FLOCKMTL_MODEL_DEFAULT_INTERNAL_TABLE"
+                    " UNION ALL "
+                    " SELECT 'global' AS scope, * "
+                    " FROM flock_storage.flock_config.FLOCKMTL_MODEL_USER_DEFINED_INTERNAL_TABLE"
+                    " UNION ALL "
+                    " SELECT 'local' AS scope, * "
+                    " FROM flock_config.FLOCKMTL_MODEL_USER_DEFINED_INTERNAL_TABLE;",
+                    true);
             break;
         }
         default:

--- a/src/custom_parser/query/prompt_parser.cpp
+++ b/src/custom_parser/query/prompt_parser.cpp
@@ -2,6 +2,7 @@
 
 #include "flock/core/common.hpp"
 #include "flock/core/config.hpp"
+#include "flock/custom_parser/query_parser.hpp"
 
 #include <sstream>
 #include <stdexcept>
@@ -216,89 +217,110 @@ std::string PromptParser::ToSQL(const QueryStatement& statement) const {
     switch (statement.type) {
         case StatementType::CREATE_PROMPT: {
             const auto& create_stmt = static_cast<const CreatePromptStatement&>(statement);
-            auto con = Config::GetConnection();
-            auto result = con.Query(duckdb_fmt::format(" SELECT prompt_name "
-                                                       "   FROM {}flock_config.FLOCKMTL_PROMPT_INTERNAL_TABLE"
-                                                       "  WHERE prompt_name = '{}';",
-                                                       create_stmt.catalog.empty() ? "flock_storage." : "",
-                                                       create_stmt.prompt_name));
-            if (result->RowCount() != 0) {
-                throw std::runtime_error(duckdb_fmt::format("Prompt '{}' already exist.", create_stmt.prompt_name));
-            }
-            query = duckdb_fmt::format(" INSERT INTO {}flock_config.FLOCKMTL_PROMPT_INTERNAL_TABLE "
-                                       " (prompt_name, prompt) "
-                                       " VALUES ('{}', '{}'); ",
-                                       create_stmt.catalog, create_stmt.prompt_name, create_stmt.prompt);
+            query = ExecuteQueryWithStorage([&create_stmt](duckdb::Connection& con) {
+                auto result = con.Query(duckdb_fmt::format(" SELECT prompt_name "
+                                                           "   FROM {}flock_config.FLOCKMTL_PROMPT_INTERNAL_TABLE"
+                                                           "  WHERE prompt_name = '{}';",
+                                                           create_stmt.catalog.empty() ? "flock_storage." : "",
+                                                           create_stmt.prompt_name));
+
+                auto& materialized_result = result->Cast<duckdb::MaterializedQueryResult>();
+                if (materialized_result.RowCount() != 0) {
+                    throw std::runtime_error(duckdb_fmt::format("Prompt '{}' already exist.", create_stmt.prompt_name));
+                }
+
+                auto insert_query = duckdb_fmt::format(" INSERT INTO {}flock_config.FLOCKMTL_PROMPT_INTERNAL_TABLE "
+                                                       " (prompt_name, prompt) "
+                                                       " VALUES ('{}', '{}'); ",
+                                                       create_stmt.catalog, create_stmt.prompt_name, create_stmt.prompt);
+                con.Query(insert_query);
+
+                return std::string("SELECT 'Prompt created successfully' AS status");
+            },
+                                            false);
             break;
         }
         case StatementType::DELETE_PROMPT: {
             const auto& delete_stmt = static_cast<const DeletePromptStatement&>(statement);
-            auto con = Config::GetConnection();
-            auto result = con.Query(duckdb_fmt::format("  DELETE FROM flock_config.FLOCKMTL_PROMPT_INTERNAL_TABLE "
-                                                       "  WHERE prompt_name = '{}'; ",
-                                                       delete_stmt.prompt_name));
-
-            query = duckdb_fmt::format(" DELETE FROM flock_storage.flock_config.FLOCKMTL_PROMPT_INTERNAL_TABLE "
+            query = ExecuteSetQuery(
+                    duckdb_fmt::format(" DELETE FROM flock_config.FLOCKMTL_PROMPT_INTERNAL_TABLE "
+                                       "  WHERE prompt_name = '{}'; "
+                                       " DELETE FROM flock_storage.flock_config.FLOCKMTL_PROMPT_INTERNAL_TABLE "
                                        "  WHERE prompt_name = '{}'; ",
-                                       delete_stmt.prompt_name);
+                                       delete_stmt.prompt_name, delete_stmt.prompt_name),
+                    "Prompt deleted successfully",
+                    false);
             break;
         }
         case StatementType::UPDATE_PROMPT: {
             const auto& update_stmt = static_cast<const UpdatePromptStatement&>(statement);
-            auto con = Config::GetConnection();
-            auto result =
-                    con.Query(duckdb_fmt::format(" SELECT version, 'local' AS scope "
-                                                 "  FROM flock_config.FLOCKMTL_PROMPT_INTERNAL_TABLE"
-                                                 " WHERE prompt_name = '{}'"
-                                                 " UNION ALL "
-                                                 " SELECT version, 'global' AS scope "
-                                                 "   FROM flock_storage.flock_config.FLOCKMTL_PROMPT_INTERNAL_TABLE"
-                                                 "  WHERE prompt_name = '{}' "
-                                                 " ORDER BY version DESC;",
-                                                 update_stmt.prompt_name, update_stmt.prompt_name));
-            if (result->RowCount() == 0) {
-                throw std::runtime_error(duckdb_fmt::format("Prompt '{}' doesn't exist.", update_stmt.prompt_name));
-            }
+            query = ExecuteQueryWithStorage([&update_stmt](duckdb::Connection& con) {
+                auto result = con.Query(duckdb_fmt::format(" SELECT version, 'local' AS scope "
+                                                           "  FROM flock_config.FLOCKMTL_PROMPT_INTERNAL_TABLE"
+                                                           " WHERE prompt_name = '{}'"
+                                                           " UNION ALL "
+                                                           " SELECT version, 'global' AS scope "
+                                                           "   FROM flock_storage.flock_config.FLOCKMTL_PROMPT_INTERNAL_TABLE"
+                                                           "  WHERE prompt_name = '{}' "
+                                                           " ORDER BY version DESC;",
+                                                           update_stmt.prompt_name, update_stmt.prompt_name));
 
-            int version = result->GetValue<int>(0, 0) + 1;
-            auto catalog = result->GetValue(1, 0).ToString() == "global" ? "flock_storage." : "";
-            query = duckdb_fmt::format(" INSERT INTO {}flock_config.FLOCKMTL_PROMPT_INTERNAL_TABLE "
-                                       " (prompt_name, prompt, version) "
-                                       " VALUES ('{}', '{}', {}); ",
-                                       catalog, update_stmt.prompt_name, update_stmt.new_prompt, version);
+                auto& materialized_result = result->Cast<duckdb::MaterializedQueryResult>();
+                if (materialized_result.RowCount() == 0) {
+                    throw std::runtime_error(duckdb_fmt::format("Prompt '{}' doesn't exist.", update_stmt.prompt_name));
+                }
+
+                int version = materialized_result.GetValue<int>(0, 0) + 1;
+                auto catalog = materialized_result.GetValue(1, 0).ToString() == "global" ? "flock_storage." : "";
+
+                con.Query(duckdb_fmt::format(" INSERT INTO {}flock_config.FLOCKMTL_PROMPT_INTERNAL_TABLE "
+                                             " (prompt_name, prompt, version) "
+                                             " VALUES ('{}', '{}', {}); ",
+                                             catalog, update_stmt.prompt_name, update_stmt.new_prompt, version));
+
+                return std::string("SELECT 'Prompt updated successfully' AS status");
+            },
+                                            false);
             break;
         }
         case StatementType::UPDATE_PROMPT_SCOPE: {
             const auto& update_stmt = static_cast<const UpdatePromptScopeStatement&>(statement);
-            auto con = Config::GetConnection();
-            auto result = con.Query(duckdb_fmt::format(" SELECT prompt_name "
-                                                       "   FROM {}flock_config.FLOCKMTL_PROMPT_INTERNAL_TABLE"
-                                                       "  WHERE prompt_name = '{}';",
-                                                       update_stmt.catalog, update_stmt.prompt_name));
-            if (result->RowCount() != 0) {
-                throw std::runtime_error(
-                        duckdb_fmt::format("Model '{}' already exist in {} storage.", update_stmt.prompt_name,
-                                           update_stmt.catalog == "flock_storage." ? "global" : "local"));
-            }
+            query = ExecuteQueryWithStorage([&update_stmt](duckdb::Connection& con) {
+                auto result = con.Query(duckdb_fmt::format(" SELECT prompt_name "
+                                                           "   FROM {}flock_config.FLOCKMTL_PROMPT_INTERNAL_TABLE"
+                                                           "  WHERE prompt_name = '{}';",
+                                                           update_stmt.catalog, update_stmt.prompt_name));
 
-            con.Query(duckdb_fmt::format("INSERT INTO {}flock_config.FLOCKMTL_PROMPT_INTERNAL_TABLE "
-                                         "(prompt_name, prompt, updated_at, version) "
-                                         "SELECT prompt_name, prompt, updated_at, version "
-                                         "FROM {}flock_config.FLOCKMTL_PROMPT_INTERNAL_TABLE "
-                                         "WHERE prompt_name = '{}';",
-                                         update_stmt.catalog,
-                                         update_stmt.catalog == "flock_storage." ? "" : "flock_storage.",
-                                         update_stmt.prompt_name));
+                auto& materialized_result = result->Cast<duckdb::MaterializedQueryResult>();
+                if (materialized_result.RowCount() != 0) {
+                    throw std::runtime_error(
+                            duckdb_fmt::format("Prompt '{}' already exist in {} storage.", update_stmt.prompt_name,
+                                               update_stmt.catalog == "flock_storage." ? "global" : "local"));
+                }
 
-            query = duckdb_fmt::format("DELETE FROM {}flock_config.FLOCKMTL_PROMPT_INTERNAL_TABLE "
-                                       "WHERE prompt_name = '{}'; ",
-                                       update_stmt.catalog == "flock_storage." ? "" : "flock_storage.",
-                                       update_stmt.prompt_name);
+                con.Query(duckdb_fmt::format("INSERT INTO {}flock_config.FLOCKMTL_PROMPT_INTERNAL_TABLE "
+                                             "(prompt_name, prompt, updated_at, version) "
+                                             "SELECT prompt_name, prompt, updated_at, version "
+                                             "FROM {}flock_config.FLOCKMTL_PROMPT_INTERNAL_TABLE "
+                                             "WHERE prompt_name = '{}';",
+                                             update_stmt.catalog,
+                                             update_stmt.catalog == "flock_storage." ? "" : "flock_storage.",
+                                             update_stmt.prompt_name));
+
+                con.Query(duckdb_fmt::format("DELETE FROM {}flock_config.FLOCKMTL_PROMPT_INTERNAL_TABLE "
+                                             "WHERE prompt_name = '{}'; ",
+                                             update_stmt.catalog == "flock_storage." ? "" : "flock_storage.",
+                                             update_stmt.prompt_name));
+
+                return std::string("SELECT 'Prompt scope updated successfully' AS status");
+            },
+                                            false);
             break;
         }
         case StatementType::GET_PROMPT: {
             const auto& get_stmt = static_cast<const GetPromptStatement&>(statement);
-            query = duckdb_fmt::format("SELECT 'global' AS scope, * "
+            query = ExecuteGetQuery(
+                    duckdb_fmt::format("SELECT 'global' AS scope, * "
                                        "FROM flock_storage.flock_config.FLOCKMTL_PROMPT_INTERNAL_TABLE "
                                        "WHERE prompt_name = '{}' "
                                        "UNION ALL "
@@ -306,12 +328,13 @@ std::string PromptParser::ToSQL(const QueryStatement& statement) const {
                                        "FROM flock_config.FLOCKMTL_PROMPT_INTERNAL_TABLE "
                                        "WHERE prompt_name = '{}' "
                                        "ORDER BY version DESC;",
-                                       get_stmt.prompt_name, get_stmt.prompt_name);
-
+                                       get_stmt.prompt_name, get_stmt.prompt_name),
+                    true);
             break;
         }
         case StatementType::GET_ALL_PROMPT: {
-            query = " SELECT 'global' as scope, t1.* "
+            query = ExecuteGetQuery(
+                    " SELECT 'global' as scope, t1.* "
                     "   FROM flock_storage.flock_config.FLOCKMTL_PROMPT_INTERNAL_TABLE AS t1 "
                     "   JOIN (SELECT prompt_name, MAX(version) AS max_version "
                     "   FROM flock_storage.flock_config.FLOCKMTL_PROMPT_INTERNAL_TABLE "
@@ -325,7 +348,8 @@ std::string PromptParser::ToSQL(const QueryStatement& statement) const {
                     "   FROM flock_config.FLOCKMTL_PROMPT_INTERNAL_TABLE "
                     "  GROUP BY prompt_name) AS t2 "
                     "     ON t1.prompt_name = t2.prompt_name "
-                    "    AND t1.version = t2.max_version; ";
+                    "    AND t1.version = t2.max_version; ",
+                    true);
             break;
         }
         default:

--- a/src/custom_parser/query_parser.cpp
+++ b/src/custom_parser/query_parser.cpp
@@ -1,11 +1,101 @@
 #include "flock/custom_parser/query_parser.hpp"
 
+#include "duckdb/main/materialized_query_result.hpp"
 #include "flock/core/common.hpp"
+#include "flock/core/config.hpp"
 
 #include <sstream>
 #include <stdexcept>
 
 namespace flock {
+
+// Format a DuckDB value for SQL (escape strings, handle NULLs)
+std::string FormatValueForSQL(const duckdb::Value& value) {
+    if (value.IsNull()) {
+        return "NULL";
+    }
+    auto str = value.ToString();
+    // Escape single quotes by doubling them
+    std::string escaped;
+    escaped.reserve(str.length() + 10);
+    for (char c: str) {
+        if (c == '\'') {
+            escaped += "''";
+        } else {
+            escaped += c;
+        }
+    }
+    return "'" + escaped + "'";
+}
+
+// Format query results as VALUES clause: SELECT * FROM VALUES (...)
+std::string FormatResultsAsValues(duckdb::unique_ptr<duckdb::QueryResult> result) {
+    if (!result) {
+        return "SELECT * FROM (VALUES (NULL)) AS empty_result WHERE FALSE";
+    }
+
+    // Cast to MaterializedQueryResult to access GetValue and RowCount
+    auto& materialized_result = result->Cast<duckdb::MaterializedQueryResult>();
+
+    if (materialized_result.RowCount() == 0) {
+        return "SELECT * FROM (VALUES (NULL)) AS empty_result WHERE FALSE";
+    }
+
+    std::ostringstream values_stream;
+    auto column_count = result->ColumnCount();
+
+    // Get column names
+    std::vector<std::string> column_names;
+    column_names.reserve(column_count);
+    for (idx_t col = 0; col < column_count; col++) {
+        column_names.push_back(result->ColumnName(col));
+    }
+
+    // Format each row as VALUES tuple
+    for (idx_t row = 0; row < materialized_result.RowCount(); row++) {
+        if (row > 0) {
+            values_stream << ", ";
+        }
+        values_stream << "(";
+        for (idx_t col = 0; col < column_count; col++) {
+            if (col > 0) {
+                values_stream << ", ";
+            }
+            auto value = materialized_result.GetValue(col, row);
+            values_stream << FormatValueForSQL(value);
+        }
+        values_stream << ")";
+    }
+
+    // Build column names for the VALUES clause
+    std::ostringstream column_names_stream;
+    for (size_t i = 0; i < column_names.size(); i++) {
+        if (i > 0) {
+            column_names_stream << ", ";
+        }
+        column_names_stream << "\"" << column_names[i] << "\"";
+    }
+
+    return duckdb_fmt::format("SELECT * FROM (VALUES {}) AS result({})",
+                              values_stream.str(), column_names_stream.str());
+}
+
+// Execute a query with storage attachment and return formatted result for GET operations
+std::string ExecuteGetQuery(const std::string& query, bool read_only) {
+    auto con = Config::GetConnection();
+    Config::StorageAttachmentGuard guard(con, read_only);
+    auto result = con.Query(query);
+    return FormatResultsAsValues(std::move(result));
+}
+
+// Execute a query with storage attachment and return status message for SET operations
+std::string ExecuteSetQuery(const std::string& query, const std::string& success_message, bool read_only) {
+    auto con = Config::GetConnection();
+    Config::StorageAttachmentGuard guard(con, read_only);
+    con.Query(query);
+    return duckdb_fmt::format("SELECT '{}' AS status", success_message);
+}
+
 
 std::string QueryParser::ParseQuery(const std::string& query) {
     Tokenizer tokenizer(query);

--- a/src/include/flock/custom_parser/query_parser.hpp
+++ b/src/include/flock/custom_parser/query_parser.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "flock/core/common.hpp"
+#include "flock/core/config.hpp"
 #include "flock/custom_parser/query/model_parser.hpp"
 #include "flock/custom_parser/query/prompt_parser.hpp"
 #include "flock/custom_parser/query_statements.hpp"
@@ -9,6 +10,20 @@
 #include "fmt/format.h"
 
 namespace flock {
+
+// Forward declarations for query execution utilities
+std::string FormatValueForSQL(const duckdb::Value& value);
+std::string FormatResultsAsValues(duckdb::unique_ptr<duckdb::QueryResult> result);
+std::string ExecuteGetQuery(const std::string& query, bool read_only);
+std::string ExecuteSetQuery(const std::string& query, const std::string& success_message, bool read_only);
+
+// Template function for executing queries with storage attachment
+template<typename Func>
+std::string ExecuteQueryWithStorage(Func&& query_func, bool read_only) {
+    auto con = Config::GetConnection();
+    Config::StorageAttachmentGuard guard(con, read_only);
+    return query_func(con);
+}
 
 class QueryParser {
 public:

--- a/src/model_manager/model.cpp
+++ b/src/model_manager/model.cpp
@@ -54,6 +54,7 @@ std::tuple<std::string, std::string, nlohmann::basic_json<>> Model::GetQueriedMo
                                model_name, model_name);
 
     auto con = Config::GetConnection();
+    Config::StorageAttachmentGuard guard(con, true);
     auto query_result = con.Query(query);
 
     if (query_result->RowCount() == 0) {

--- a/src/prompt_manager/prompt_manager.cpp
+++ b/src/prompt_manager/prompt_manager.cpp
@@ -214,6 +214,7 @@ PromptDetails PromptManager::CreatePromptDetails(const nlohmann::json& prompt_de
                                        version_where_clause, order_by_clause);
             error_message = duckdb_fmt::format("The provided `{}` prompt " + error_message, prompt_details.prompt_name);
             auto con = Config::GetConnection();
+            Config::StorageAttachmentGuard guard(con, true);
             const auto query_result = con.Query(prompt_details_query);
             if (query_result->RowCount() == 0) {
                 throw std::runtime_error(error_message);


### PR DESCRIPTION
**Changes:**
- Add `StorageAttachmentGuard` class to `Config` for automatic attach/detach
- Implement retry mechanism (10 retries, 1s delay) for attach operations
- Refactor custom parser: move formatting utilities to `query_parser.cpp`
- Update `ToSQL()` to execute queries and return results as VALUES or status tables
- Replace manual attach/detach calls with `StorageAttachmentGuard` in model and prompt managers