### PR TITLE
Fix duplicate check for CREATE MODEL and CREATE PROMPT

### DIFF
--- a/src/custom_parser/query/model_parser.cpp
+++ b/src/custom_parser/query/model_parser.cpp
@@ -305,16 +305,19 @@ std::string ModelParser::ToSQL(const QueryStatement& statement) const {
         case StatementType::CREATE_MODEL: {
             const auto& create_stmt = static_cast<const CreateModelStatement&>(statement);
             query = ExecuteQueryWithStorage([&create_stmt](duckdb::Connection& con) {
-                // Check if model already exists
                 auto result = con.Query(duckdb_fmt::format(
                         " SELECT model_name"
                         "  FROM flock_storage.flock_config.FLOCKMTL_MODEL_DEFAULT_INTERNAL_TABLE"
                         " WHERE model_name = '{}'"
                         " UNION ALL "
                         " SELECT model_name "
-                        "   FROM {}flock_config.FLOCKMTL_MODEL_USER_DEFINED_INTERNAL_TABLE"
+                        "   FROM flock_storage.flock_config.FLOCKMTL_MODEL_USER_DEFINED_INTERNAL_TABLE"
+                        "  WHERE model_name = '{}'"
+                        " UNION ALL "
+                        " SELECT model_name "
+                        "   FROM flock_config.FLOCKMTL_MODEL_USER_DEFINED_INTERNAL_TABLE"
                         "  WHERE model_name = '{}';",
-                        create_stmt.model_name, create_stmt.catalog.empty() ? "flock_storage." : "", create_stmt.model_name));
+                        create_stmt.model_name, create_stmt.model_name, create_stmt.model_name));
 
                 auto& materialized_result = result->Cast<duckdb::MaterializedQueryResult>();
                 if (materialized_result.RowCount() != 0) {

--- a/src/custom_parser/query/prompt_parser.cpp
+++ b/src/custom_parser/query/prompt_parser.cpp
@@ -219,10 +219,13 @@ std::string PromptParser::ToSQL(const QueryStatement& statement) const {
             const auto& create_stmt = static_cast<const CreatePromptStatement&>(statement);
             query = ExecuteQueryWithStorage([&create_stmt](duckdb::Connection& con) {
                 auto result = con.Query(duckdb_fmt::format(" SELECT prompt_name "
-                                                           "   FROM {}flock_config.FLOCKMTL_PROMPT_INTERNAL_TABLE"
+                                                           "   FROM flock_storage.flock_config.FLOCKMTL_PROMPT_INTERNAL_TABLE"
+                                                           "  WHERE prompt_name = '{}'"
+                                                           " UNION ALL "
+                                                           " SELECT prompt_name "
+                                                           "   FROM flock_config.FLOCKMTL_PROMPT_INTERNAL_TABLE"
                                                            "  WHERE prompt_name = '{}';",
-                                                           create_stmt.catalog.empty() ? "flock_storage." : "",
-                                                           create_stmt.prompt_name));
+                                                           create_stmt.prompt_name, create_stmt.prompt_name));
 
                 auto& materialized_result = result->Cast<duckdb::MaterializedQueryResult>();
                 if (materialized_result.RowCount() != 0) {


### PR DESCRIPTION
CREATE MODEL and CREATE PROMPT commands were not properly detecting duplicates when a model/prompt already existed in a different table (global vs local). This allowed duplicate creations to succeed, showing "created successfully" for both attempts.
