### PR TITLE
Update session.hpp: added long to curl_easy_setopt

### DIFF
--- a/src/include/flock/model_manager/providers/handlers/session.hpp
+++ b/src/include/flock/model_manager/providers/handlers/session.hpp
@@ -43,7 +43,7 @@ public:
         if (curl_ == nullptr) {
             throw std::runtime_error("curl cannot initialize");// here we throw it shouldn't happen
         }
-        curl_easy_setopt(curl_, CURLOPT_NOSIGNAL, 1);
+        curl_easy_setopt(curl_, CURLOPT_NOSIGNAL, 1L);
     }
 
     void ignoreSSL() { curl_easy_setopt(curl_, CURLOPT_SSL_VERIFYPEER, 0L); }


### PR DESCRIPTION
The cURL docs insist on this being a long: https://everything.curl.dev/transfers/options/num.html
