### PR TITLE
[codex] Fix Flock unit test fixtures and explicit model configs

### DIFF
--- a/src/model_manager/model.cpp
+++ b/src/model_manager/model.cpp
@@ -26,19 +26,31 @@ void Model::LoadModelDetails(const nlohmann::json& model_json) {
     }
 
     bool has_resolved_details = model_json.contains("model") &&
-                                model_json.contains("provider") &&
-                                model_json.contains("secret") &&
-                                model_json.contains("tuple_format") &&
-                                model_json.contains("batch_size");
+                                model_json.contains("provider");
 
     nlohmann::json db_model_args;
 
     if (has_resolved_details) {
         model_details_.model = model_json.at("model").get<std::string>();
         model_details_.provider_name = model_json.at("provider").get<std::string>();
-        model_details_.secret = model_json["secret"].get<std::unordered_map<std::string, std::string>>();
-        model_details_.tuple_format = model_json.at("tuple_format").get<std::string>();
-        model_details_.batch_size = model_json.at("batch_size").get<int>();
+        if (model_json.contains("secret")) {
+            model_details_.secret = model_json["secret"].get<std::unordered_map<std::string, std::string>>();
+        } else {
+            auto secret_name = "__default_" + model_details_.provider_name;
+            if (model_details_.provider_name == AZURE) {
+                secret_name += "_llm";
+            }
+            if (model_json.contains("secret_name")) {
+                secret_name = model_json["secret_name"].get<std::string>();
+            }
+            model_details_.secret = SecretManager::GetSecret(secret_name);
+        }
+        model_details_.tuple_format = model_json.contains("tuple_format")
+                                      ? model_json.at("tuple_format").get<std::string>()
+                                      : "XML";
+        model_details_.batch_size = model_json.contains("batch_size")
+                                    ? model_json.at("batch_size").get<int>()
+                                    : 2048;
 
         if (model_json.contains("model_parameters")) {
             auto& mp = model_json.at("model_parameters");

--- a/test/unit/functions/aggregate/llm_aggregate_function_test_base.hpp
+++ b/test/unit/functions/aggregate/llm_aggregate_function_test_base.hpp
@@ -24,12 +24,18 @@ protected:
 
     void SetUp() override {
         auto con = Config::GetConnection();
+        Config::ConfigureTables(con, ConfigType::LOCAL);
         con.Query(" CREATE SECRET ("
                   "       TYPE OPENAI,"
                   "    API_KEY 'your-api-key');");
         con.Query("  CREATE SECRET ("
                   "       TYPE OLLAMA,"
                   "    API_URL '127.0.0.1:11434');");
+        con.Query(" DELETE FROM flock_config.FLOCKMTL_MODEL_USER_DEFINED_INTERNAL_TABLE "
+                  "  WHERE model_name = 'gemma3:4b';");
+        con.Query(" INSERT INTO flock_config.FLOCKMTL_MODEL_USER_DEFINED_INTERNAL_TABLE "
+                  "        (model_name, model, provider_name, model_args) "
+                  " VALUES ('gemma3:4b', 'gemma3:4b', 'ollama', '{}');");
 
         // Create a shared mock provider for expectations
         mock_provider = std::make_shared<MockProvider>(ModelDetails{});

--- a/test/unit/functions/aggregate/llm_aggregate_function_test_base.hpp
+++ b/test/unit/functions/aggregate/llm_aggregate_function_test_base.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "../mock_provider.hpp"
+#include "../../ollama_test_utils.hpp"
 #include "flock/core/config.hpp"
 #include "flock/functions/aggregate/aggregate.hpp"
 #include "flock/model_manager/model.hpp"
@@ -31,11 +32,7 @@ protected:
         con.Query("  CREATE SECRET ("
                   "       TYPE OLLAMA,"
                   "    API_URL '127.0.0.1:11434');");
-        con.Query(" DELETE FROM flock_config.FLOCKMTL_MODEL_USER_DEFINED_INTERNAL_TABLE "
-                  "  WHERE model_name = 'gemma3:4b';");
-        con.Query(" INSERT INTO flock_config.FLOCKMTL_MODEL_USER_DEFINED_INTERNAL_TABLE "
-                  "        (model_name, model, provider_name, model_args) "
-                  " VALUES ('gemma3:4b', 'gemma3:4b', 'ollama', '{}');");
+        SeedOllamaTestModel(con);
 
         // Create a shared mock provider for expectations
         mock_provider = std::make_shared<MockProvider>(ModelDetails{});

--- a/test/unit/functions/aggregate/llm_first.cpp
+++ b/test/unit/functions/aggregate/llm_first.cpp
@@ -1,4 +1,5 @@
 #include "flock/functions/aggregate/llm_first_or_last.hpp"
+#include "../../ollama_test_utils.hpp"
 #include "llm_aggregate_function_test_base.hpp"
 
 namespace flock {
@@ -185,17 +186,20 @@ TEST_F(LLMFirstTest, AudioTranscription) {
 // Test audio transcription error handling for Ollama
 TEST_F(LLMFirstTest, AudioTranscriptionOllamaError) {
     auto con = Config::GetConnection();
+    const auto ollama_model = GetOllamaTestModelName();
     EXPECT_CALL(*mock_provider, AddTranscriptionRequest(::testing::_))
             .WillOnce(::testing::Throw(std::runtime_error("Audio transcription is not currently supported by Ollama.")));
 
     const auto results = con.Query(
             "SELECT llm_first("
-            "{'model_name': 'gemma3:4b'}, "
+            "{'model_name': '" +
+            ollama_model + "'}, "
             "{'prompt': 'Select the best audio', "
             "'context_columns': ["
             "{'data': audio_url, "
             "'type': 'audio', "
-            "'transcription_model': 'gemma3:4b'}"
+            "'transcription_model': '" +
+            ollama_model + "'}"
             "]}) AS result FROM VALUES "
             "('https://example.com/audio1.mp3'), "
             "('https://example.com/audio2.mp3') AS tbl(audio_url);");

--- a/test/unit/functions/aggregate/llm_last.cpp
+++ b/test/unit/functions/aggregate/llm_last.cpp
@@ -1,4 +1,5 @@
 #include "flock/functions/aggregate/llm_first_or_last.hpp"
+#include "../../ollama_test_utils.hpp"
 #include "llm_aggregate_function_test_base.hpp"
 
 namespace flock {
@@ -185,17 +186,20 @@ TEST_F(LLMLastTest, AudioTranscription) {
 // Test audio transcription error handling for Ollama
 TEST_F(LLMLastTest, AudioTranscriptionOllamaError) {
     auto con = Config::GetConnection();
+    const auto ollama_model = GetOllamaTestModelName();
     EXPECT_CALL(*mock_provider, AddTranscriptionRequest(::testing::_))
             .WillOnce(::testing::Throw(std::runtime_error("Audio transcription is not currently supported by Ollama.")));
 
     const auto results = con.Query(
             "SELECT llm_last("
-            "{'model_name': 'gemma3:4b'}, "
+            "{'model_name': '" +
+            ollama_model + "'}, "
             "{'prompt': 'Select the worst audio', "
             "'context_columns': ["
             "{'data': audio_url, "
             "'type': 'audio', "
-            "'transcription_model': 'gemma3:4b'}"
+            "'transcription_model': '" +
+            ollama_model + "'}"
             "]}) AS result FROM VALUES "
             "('https://example.com/audio1.mp3'), "
             "('https://example.com/audio2.mp3') AS tbl(audio_url);");

--- a/test/unit/functions/aggregate/llm_reduce.cpp
+++ b/test/unit/functions/aggregate/llm_reduce.cpp
@@ -1,4 +1,5 @@
 #include "flock/functions/aggregate/llm_reduce.hpp"
+#include "../../ollama_test_utils.hpp"
 #include "llm_aggregate_function_test_base.hpp"
 
 namespace flock {
@@ -209,17 +210,20 @@ TEST_F(LLMReduceTest, AudioAndTextColumns) {
 // Test audio transcription error handling for Ollama
 TEST_F(LLMReduceTest, AudioTranscriptionOllamaError) {
     auto con = Config::GetConnection();
+    const auto ollama_model = GetOllamaTestModelName();
     EXPECT_CALL(*mock_provider, AddTranscriptionRequest(::testing::_))
             .WillOnce(::testing::Throw(std::runtime_error("Audio transcription is not currently supported by Ollama.")));
 
     const auto results = con.Query(
             "SELECT llm_reduce("
-            "{'model_name': 'gemma3:4b'}, "
+            "{'model_name': '" +
+            ollama_model + "'}, "
             "{'prompt': 'Summarize this audio', "
             "'context_columns': ["
             "{'data': audio_url, "
             "'type': 'audio', "
-            "'transcription_model': 'gemma3:4b'}"
+            "'transcription_model': '" +
+            ollama_model + "'}"
             "]}) AS result FROM VALUES ('https://example.com/audio.mp3') AS tbl(audio_url);");
 
     ASSERT_TRUE(results->HasError());

--- a/test/unit/functions/aggregate/llm_rerank.cpp
+++ b/test/unit/functions/aggregate/llm_rerank.cpp
@@ -1,4 +1,5 @@
 #include "flock/functions/aggregate/llm_rerank.hpp"
+#include "../../ollama_test_utils.hpp"
 #include "llm_aggregate_function_test_base.hpp"
 #include <numeric>
 
@@ -196,17 +197,20 @@ TEST_F(LLMRerankTest, AudioTranscription) {
 // Test audio transcription error handling for Ollama
 TEST_F(LLMRerankTest, AudioTranscriptionOllamaError) {
     auto con = Config::GetConnection();
+    const auto ollama_model = GetOllamaTestModelName();
     EXPECT_CALL(*mock_provider, AddTranscriptionRequest(::testing::_))
             .WillOnce(::testing::Throw(std::runtime_error("Audio transcription is not currently supported by Ollama.")));
 
     const auto results = con.Query(
             "SELECT llm_rerank("
-            "{'model_name': 'gemma3:4b'}, "
+            "{'model_name': '" +
+            ollama_model + "'}, "
             "{'prompt': 'Rank these audio files', "
             "'context_columns': ["
             "{'data': audio_url, "
             "'type': 'audio', "
-            "'transcription_model': 'gemma3:4b'}"
+            "'transcription_model': '" +
+            ollama_model + "'}"
             "]}) AS result FROM VALUES "
             "('https://example.com/audio1.mp3'), "
             "('https://example.com/audio2.mp3') AS tbl(audio_url);");

--- a/test/unit/functions/scalar/llm_complete.cpp
+++ b/test/unit/functions/scalar/llm_complete.cpp
@@ -1,4 +1,5 @@
 #include "flock/functions/scalar/llm_complete.hpp"
+#include "../../ollama_test_utils.hpp"
 #include "llm_function_test_base.hpp"
 
 namespace flock {
@@ -227,6 +228,7 @@ TEST_F(LLMCompleteTest, LLMCompleteWithAudioAndText) {
 // Test audio transcription error handling
 TEST_F(LLMCompleteTest, LLMCompleteAudioTranscriptionError) {
     auto con = Config::GetConnection();
+    const auto ollama_model = GetOllamaTestModelName();
     // Mock transcription model to throw error (simulating Ollama behavior)
     EXPECT_CALL(*mock_provider, AddTranscriptionRequest(::testing::_))
             .WillOnce(::testing::Throw(std::runtime_error("Audio transcription is not currently supported by Ollama.")));
@@ -234,12 +236,14 @@ TEST_F(LLMCompleteTest, LLMCompleteAudioTranscriptionError) {
     // Test with Ollama which doesn't support transcription
     const auto results = con.Query(
             "SELECT llm_complete("
-            "{'model_name': 'gemma3:4b'}, "
+            "{'model_name': '" +
+            ollama_model + "'}, "
             "{'prompt': 'Summarize this audio', "
             "'context_columns': ["
             "{'data': audio_url, "
             "'type': 'audio', "
-            "'transcription_model': 'gemma3:4b'}"
+            "'transcription_model': '" +
+            ollama_model + "'}"
             "]}) AS result FROM VALUES ('https://example.com/audio.mp3') AS tbl(audio_url);");
 
     // Should fail because Ollama doesn't support transcription

--- a/test/unit/functions/scalar/llm_filter.cpp
+++ b/test/unit/functions/scalar/llm_filter.cpp
@@ -1,4 +1,5 @@
 #include "flock/functions/scalar/llm_filter.hpp"
+#include "../../ollama_test_utils.hpp"
 #include "llm_function_test_base.hpp"
 
 namespace flock {
@@ -196,6 +197,7 @@ TEST_F(LLMFilterTest, LLMFilterWithAudioAndText) {
 // Test audio transcription error handling for Ollama
 TEST_F(LLMFilterTest, LLMFilterAudioTranscriptionOllamaError) {
     auto con = Config::GetConnection();
+    const auto ollama_model = GetOllamaTestModelName();
 
     // Mock transcription model to throw error (simulating Ollama behavior)
     EXPECT_CALL(*mock_provider, AddTranscriptionRequest(::testing::_))
@@ -204,12 +206,14 @@ TEST_F(LLMFilterTest, LLMFilterAudioTranscriptionOllamaError) {
     // Test with Ollama which doesn't support transcription
     const auto results = con.Query(
             "SELECT llm_filter("
-            "{'model_name': 'gemma3:4b'}, "
+            "{'model_name': '" +
+            ollama_model + "'}, "
             "{'prompt': 'Is the sentiment positive?', "
             "'context_columns': ["
             "{'data': audio_url, "
             "'type': 'audio', "
-            "'transcription_model': 'gemma3:4b'}"
+            "'transcription_model': '" +
+            ollama_model + "'}"
             "]}) AS result FROM VALUES ('https://example.com/audio.mp3') AS tbl(audio_url);");
 
     // Should fail because Ollama doesn't support transcription

--- a/test/unit/functions/scalar/llm_function_test_base_instantiations.cpp
+++ b/test/unit/functions/scalar/llm_function_test_base_instantiations.cpp
@@ -1,6 +1,7 @@
 #include "flock/functions/scalar/llm_complete.hpp"
 #include "flock/functions/scalar/llm_embedding.hpp"
 #include "flock/functions/scalar/llm_filter.hpp"
+#include "../../ollama_test_utils.hpp"
 #include "llm_function_test_base.hpp"
 
 namespace flock {
@@ -16,11 +17,7 @@ void LLMFunctionTestBase<FunctionClass>::SetUp() {
     con.Query("  CREATE SECRET ("
               "       TYPE OLLAMA,"
               "    API_URL '127.0.0.1:11434');");
-    con.Query(" DELETE FROM flock_config.FLOCKMTL_MODEL_USER_DEFINED_INTERNAL_TABLE "
-              "  WHERE model_name = 'gemma3:4b';");
-    con.Query(" INSERT INTO flock_config.FLOCKMTL_MODEL_USER_DEFINED_INTERNAL_TABLE "
-              "        (model_name, model, provider_name, model_args) "
-              " VALUES ('gemma3:4b', 'gemma3:4b', 'ollama', '{}');");
+    SeedOllamaTestModel(con);
 
     mock_provider = std::make_shared<MockProvider>(ModelDetails{});
     Model::SetMockProvider(mock_provider);

--- a/test/unit/functions/scalar/llm_function_test_base_instantiations.cpp
+++ b/test/unit/functions/scalar/llm_function_test_base_instantiations.cpp
@@ -9,12 +9,18 @@ namespace flock {
 template<typename FunctionClass>
 void LLMFunctionTestBase<FunctionClass>::SetUp() {
     auto con = Config::GetConnection();
+    Config::ConfigureTables(con, ConfigType::LOCAL);
     con.Query(" CREATE SECRET ("
               "       TYPE OPENAI,"
               "    API_KEY 'your-api-key');");
     con.Query("  CREATE SECRET ("
               "       TYPE OLLAMA,"
               "    API_URL '127.0.0.1:11434');");
+    con.Query(" DELETE FROM flock_config.FLOCKMTL_MODEL_USER_DEFINED_INTERNAL_TABLE "
+              "  WHERE model_name = 'gemma3:4b';");
+    con.Query(" INSERT INTO flock_config.FLOCKMTL_MODEL_USER_DEFINED_INTERNAL_TABLE "
+              "        (model_name, model, provider_name, model_args) "
+              " VALUES ('gemma3:4b', 'gemma3:4b', 'ollama', '{}');");
 
     mock_provider = std::make_shared<MockProvider>(ModelDetails{});
     Model::SetMockProvider(mock_provider);

--- a/test/unit/model_manager/model_manager_test.cpp
+++ b/test/unit/model_manager/model_manager_test.cpp
@@ -11,6 +11,7 @@ class ModelManagerTest : public ::testing::Test {
 protected:
     void SetUp() override {
         auto con = Config::GetConnection();
+        Config::ConfigureTables(con, ConfigType::LOCAL);
         con.Query(" CREATE SECRET ("
                   "       TYPE OPENAI,"
                   "    API_KEY 'your-api-key');");
@@ -22,6 +23,13 @@ protected:
         con.Query("  CREATE SECRET ("
                   "       TYPE OLLAMA,"
                   "    API_URL '127.0.0.1:11434');");
+        con.Query(" DELETE FROM flock_config.FLOCKMTL_MODEL_USER_DEFINED_INTERNAL_TABLE "
+                  "  WHERE model_name IN ('gpt-4o-test', 'azure-gpt-4o-mini', 'gemma3:4b');");
+        con.Query(" INSERT INTO flock_config.FLOCKMTL_MODEL_USER_DEFINED_INTERNAL_TABLE "
+                  "        (model_name, model, provider_name, model_args) "
+                  " VALUES ('gpt-4o-test', 'gpt-4o', 'openai', '{}'), "
+                  "        ('azure-gpt-4o-mini', 'gpt-4o-mini', 'azure', '{}'), "
+                  "        ('gemma3:4b', 'gemma3:4b', 'ollama', '{}');");
     }
 
     void TearDown() override {

--- a/test/unit/model_manager/model_manager_test.cpp
+++ b/test/unit/model_manager/model_manager_test.cpp
@@ -1,4 +1,5 @@
 #include "flock/model_manager/model.hpp"
+#include "../ollama_test_utils.hpp"
 #include "nlohmann/json.hpp"
 #include <gtest/gtest.h>
 #include <memory>
@@ -24,12 +25,12 @@ protected:
                   "       TYPE OLLAMA,"
                   "    API_URL '127.0.0.1:11434');");
         con.Query(" DELETE FROM flock_config.FLOCKMTL_MODEL_USER_DEFINED_INTERNAL_TABLE "
-                  "  WHERE model_name IN ('gpt-4o-test', 'azure-gpt-4o-mini', 'gemma3:4b');");
+                  "  WHERE model_name IN ('gpt-4o-test', 'azure-gpt-4o-mini');");
         con.Query(" INSERT INTO flock_config.FLOCKMTL_MODEL_USER_DEFINED_INTERNAL_TABLE "
                   "        (model_name, model, provider_name, model_args) "
                   " VALUES ('gpt-4o-test', 'gpt-4o', 'openai', '{}'), "
-                  "        ('azure-gpt-4o-mini', 'gpt-4o-mini', 'azure', '{}'), "
-                  "        ('gemma3:4b', 'gemma3:4b', 'ollama', '{}');");
+                  "        ('azure-gpt-4o-mini', 'gpt-4o-mini', 'azure', '{}');");
+        SeedOllamaTestModel(con);
     }
 
     void TearDown() override {
@@ -107,7 +108,7 @@ TEST_F(ModelManagerTest, ProviderSelection) {
     });
     // Test Ollama provider
     json ollama_config = {
-            {"model_name", "gemma3:4b"}};
+            {"model_name", GetOllamaTestModelName()}};
     EXPECT_NO_THROW({
         Model ollama_model(ollama_config);
         EXPECT_EQ(ollama_model.GetModelDetails().provider_name, "ollama");

--- a/test/unit/model_manager/model_providers_test.cpp
+++ b/test/unit/model_manager/model_providers_test.cpp
@@ -1,4 +1,5 @@
 #include "../functions/mock_provider.hpp"
+#include "../ollama_test_utils.hpp"
 #include "flock/model_manager/providers/adapters/anthropic.hpp"
 #include "flock/model_manager/providers/adapters/azure.hpp"
 #include "flock/model_manager/providers/adapters/ollama.hpp"
@@ -102,7 +103,7 @@ TEST(ModelProvidersTest, AzureProviderTest) {
 TEST(ModelProvidersTest, OllamaProviderTest) {
     ModelDetails model_details;
     model_details.model_name = "test_model";
-    model_details.model = "gemma3:4b";
+    model_details.model = GetOllamaTestModelName();
     model_details.provider_name = "ollama";
     model_details.model_parameters = {{"temperature", 0.7}};
     model_details.secret = {{"api_url", "http://localhost:11434"}};
@@ -159,7 +160,7 @@ TEST(ModelProvidersTest, OllamaProviderTest) {
 TEST(ModelProvidersTest, OllamaProviderTranscriptionError) {
     ModelDetails model_details;
     model_details.model_name = "test_model";
-    model_details.model = "gemma3:4b";
+    model_details.model = GetOllamaTestModelName();
     model_details.provider_name = "ollama";
     model_details.model_parameters = {{"temperature", 0.7}};
     model_details.secret = {{"api_url", "http://localhost:11434"}};

--- a/test/unit/ollama_test_utils.hpp
+++ b/test/unit/ollama_test_utils.hpp
@@ -1,0 +1,59 @@
+#pragma once
+
+#include "flock/core/config.hpp"
+#include "nlohmann/json.hpp"
+#include <array>
+#include <cstdio>
+#include <cstdlib>
+#include <stdexcept>
+#include <string>
+
+namespace flock {
+
+inline std::string ReadCommandOutput(const std::string& command) {
+    std::array<char, 256> buffer {};
+    std::string output;
+
+    auto pipe = popen(command.c_str(), "r");
+    if (!pipe) {
+        throw std::runtime_error("Failed to query Ollama models");
+    }
+
+    while (fgets(buffer.data(), static_cast<int>(buffer.size()), pipe) != nullptr) {
+        output += buffer.data();
+    }
+
+    const auto status = pclose(pipe);
+    if (status != 0) {
+        throw std::runtime_error("Failed to query Ollama models. Is Ollama running?");
+    }
+
+    return output;
+}
+
+inline std::string GetOllamaTestModelName() {
+    const auto* model_name = std::getenv("FLOCK_OLLAMA_TEST_MODEL");
+    if (model_name && model_name[0] != '\0') {
+        return model_name;
+    }
+
+    const auto response = ReadCommandOutput("curl -fsS http://127.0.0.1:11434/api/tags");
+    const auto tags = nlohmann::json::parse(response);
+    if (!tags.contains("models") || !tags["models"].is_array() || tags["models"].empty()) {
+        throw std::runtime_error("No Ollama models are downloaded. Pull a model or set FLOCK_OLLAMA_TEST_MODEL.");
+    }
+
+    return tags["models"][0]["name"].get<std::string>();
+}
+
+inline void SeedOllamaTestModel(duckdb::Connection& con) {
+    const auto model_name = GetOllamaTestModelName();
+    con.Query(" DELETE FROM flock_config.FLOCKMTL_MODEL_USER_DEFINED_INTERNAL_TABLE "
+              "  WHERE provider_name = 'ollama';");
+    con.Query(" INSERT INTO flock_config.FLOCKMTL_MODEL_USER_DEFINED_INTERNAL_TABLE "
+              "        (model_name, model, provider_name, model_args) "
+              " VALUES ('" +
+              model_name + "', '" + model_name + "', 'ollama', '{}');");
+}
+
+}// namespace flock

--- a/test/unit/prompt_manager/prompt_manager_test.cpp
+++ b/test/unit/prompt_manager/prompt_manager_test.cpp
@@ -11,6 +11,21 @@
 namespace flock {
 using json = nlohmann::json;
 
+void SeedProductSummaryPrompts() {
+    auto con = Config::GetConnection();
+    Config::ConfigureTables(con, ConfigType::LOCAL);
+    con.Query(" DELETE FROM flock_config.FLOCKMTL_PROMPT_INTERNAL_TABLE "
+              "  WHERE prompt_name = 'product_summary';");
+    con.Query(" INSERT INTO flock_config.FLOCKMTL_PROMPT_INTERNAL_TABLE "
+              "        (prompt_name, prompt, version) "
+              " VALUES ('product_summary', "
+              "         'Summarize the product with a persuasive tone suitable for a sales page.', "
+              "         4), "
+              "        ('product_summary', "
+              "         'Generate a summary with a focus on technical specifications.', "
+              "         6);");
+}
+
 // Test cases for PromptManager::ToString<PromptSection>
 TEST(PromptManager, ToString) {
     EXPECT_EQ(PromptManager::ToString(PromptSection::USER_PROMPT), "{{USER_PROMPT}}");
@@ -191,6 +206,7 @@ TEST(PromptManager, CreatePromptDetailsEmptyJson) {
 
 // Test with prompt_name and a specific version
 TEST(PromptManager, CreatePromptDetailsWithExplicitVersion) {
+    SeedProductSummaryPrompts();
     const json prompt_json = {
             {"prompt_name", "product_summary"},
             {"version", "4"}};
@@ -209,6 +225,7 @@ TEST(PromptManager, CreatePromptDetailsNonExistentPrompt) {
 
 // Test with a non-existent version of existing prompt
 TEST(PromptManager, CreatePromptDetailsNonExistentVersion) {
+    SeedProductSummaryPrompts();
     const json prompt_json = {
             {"prompt_name", "product_summary"},
             {"version", "999"}};
@@ -245,6 +262,7 @@ TEST(PromptManager, CreatePromptDetailsMultipleFieldsPromptOnly) {
 }
 
 TEST(PromptManager, CreatePromptDetailsOnlyPromptName) {
+    SeedProductSummaryPrompts();
     const json prompt_json = {{"prompt_name", "product_summary"}};
     const auto [prompt_name, prompt, version] = PromptManager::CreatePromptDetails(prompt_json);
     EXPECT_EQ(prompt_name, "product_summary");


### PR DESCRIPTION
## Summary

- Allow explicit model configs with `model` and `provider` to resolve without a catalog row, using default secrets and defaults for optional fields.
- Seed missing test-only model and prompt fixtures in unit test setup.
- Restore expected Ollama audio transcription error coverage.

## Validation

- `cmake --build build/ninja-release --target flock_tests`
- `build/ninja-release/extension/flock/test/unit/flock_tests --gtest_filter='LLMFirstTest.AudioTranscriptionOllamaError:LLMLastTest.AudioTranscriptionOllamaError:LLMReduceTest.AudioTranscriptionOllamaError:LLMRerankTest.AudioTranscriptionOllamaError:LLMCompleteTest.LLMCompleteAudioTranscriptionError:LLMFilterTest.LLMFilterAudioTranscriptionOllamaError:ModelManagerTest.*:PromptManager.CreatePromptDetailsWithExplicitVersion:PromptManager.CreatePromptDetailsOnlyPromptName:PromptManager.CreatePromptDetailsNonExistentVersion'`
- `build/ninja-release/extension/flock/test/unit/flock_tests`
- `git diff --check`

Note: `clang-format` was not available on PATH, so no formatter command was run.
