### PR TITLE
Use streaming

### DIFF
--- a/src/functions/input_parser.cpp
+++ b/src/functions/input_parser.cpp
@@ -91,6 +91,11 @@ nlohmann::json CastVectorOfStructsToJson(const duckdb::Vector& struct_vector, co
                     throw std::runtime_error("Expected 'is_async' to be a boolean.");
                 }
                 struct_json[key] = value.GetValue<bool>();
+            } else if (key == "stream") {
+                if (value.GetTypeMutable().id() != duckdb::LogicalTypeId::BOOLEAN) {
+                    throw std::runtime_error("Expected 'stream' to be a boolean.");
+                }
+                struct_json[key] = value.GetValue<bool>();
             } else {
                 struct_json[key] = value.ToString();
             }

--- a/src/include/flock/model_manager/providers/adapters/anthropic.hpp
+++ b/src/include/flock/model_manager/providers/adapters/anthropic.hpp
@@ -15,9 +15,23 @@ public:
             it != model_details_.secret.end()) {
             api_version = it->second;
         }
+        std::string api_key = "";
+        if (model_details_.secret.count("api_key")) {
+            api_key = model_details_.secret.at("api_key");
+        }
+        std::string api_url = "";
+        if (model_details_.secret.count("api_url")) {
+            api_url = model_details_.secret.at("api_url");
+            // Strip trailing path segments that will be added by getCompletionUrl
+            // e.g., "http://localhost:11434/v1/messages" → "http://localhost:11434/v1/"
+            if (api_url.size() > 10 && api_url.substr(api_url.size() - 8) == "/messages") {
+                api_url = api_url.substr(0, api_url.size() - 8);
+            }
+        }
         model_handler_ = std::make_unique<AnthropicModelManager>(
-                model_details_.secret.at("api_key"), api_version, true, model_details_.model_name,
-                model_details_.rate_limit, model_details_.usage_limit, rate_limiter_, usage_limiter_);
+                api_key, api_version, true, model_details_.model_name,
+                model_details_.rate_limit, model_details_.usage_limit, rate_limiter_, usage_limiter_,
+                api_url);
     }
 
     void AddCompletionRequest(const std::string& prompt, const int num_output_tuples,

--- a/src/include/flock/model_manager/providers/handlers/anthropic.hpp
+++ b/src/include/flock/model_manager/providers/handlers/anthropic.hpp
@@ -15,16 +15,27 @@ namespace flock {
 class AnthropicModelManager : public BaseModelProviderHandler {
 public:
     AnthropicModelManager(std::string api_key, std::string api_version, bool throw_exception,
-                          const std::string& model_name = "", std::optional<int> rate_limit = std::nullopt,
+                          const std::string& model_name = "",
+                          std::optional<int> rate_limit = std::nullopt,
                           std::optional<UsageLimit> usage_limit = std::nullopt,
                           std::shared_ptr<ModelRateLimiter> rate_limiter = nullptr,
-                          std::shared_ptr<ModelUsageLimiter> usage_limiter = nullptr)
+                          std::shared_ptr<ModelUsageLimiter> usage_limiter = nullptr,
+                          std::string custom_api_url = "")
         : BaseModelProviderHandler(throw_exception, model_name, rate_limit, std::move(usage_limit),
                                    std::move(rate_limiter), std::move(usage_limiter)),
           _api_key(std::move(api_key)),
           _api_version(std::move(api_version)),
-          _session("Anthropic", throw_exception) {
-        _api_base_url = "https://api.anthropic.com/v1/";
+          _session("Anthropic", throw_exception),
+          _custom_api_url(std::move(custom_api_url)) {
+        if (!_custom_api_url.empty()) {
+            _api_base_url = _custom_api_url;
+            // Ensure trailing slash for URL concatenation with getCompletionUrl
+            if (_api_base_url.back() != '/') {
+                _api_base_url += '/';
+            }
+        } else {
+            _api_base_url = "https://api.anthropic.com/v1/";
+        }
         _session.setUrl(_api_base_url);
     }
 
@@ -37,6 +48,7 @@ protected:
     std::string _api_key;
     std::string _api_version;
     std::string _api_base_url;
+    std::string _custom_api_url;
     Session _session;
 
     std::string getCompletionUrl() const override {
@@ -96,7 +108,9 @@ protected:
     }
 
     nlohmann::json ExtractCompletionOutput(const nlohmann::json& response) const override {
+
         if (!response.contains("content") || !response["content"].is_array() || response["content"].empty()) {
+
             return {};
         }
         const auto& content = response["content"];
@@ -127,6 +141,23 @@ protected:
                 }
             }
         }
+
+        // Finally, fall back to thinking blocks (Qwen models via Ollama's Anthropic API)
+        for (const auto& block: content) {
+            if (block.contains("type") && block["type"] == "thinking" && block.contains("thinking")) {
+                std::string text = block["thinking"].get<std::string>();
+                try {
+                    auto parsed = nlohmann::json::parse(text);
+                    if (parsed.contains("items") && !parsed["items"].is_array()) {
+                        parsed["items"] = nlohmann::json::array({parsed["items"]});
+                    }
+                    return parsed;
+                } catch (...) {
+                    return nlohmann::json({{"items", nlohmann::json::array({text})}});
+                }
+            }
+        }
+
         return {};
     }
 
@@ -158,13 +189,17 @@ protected:
     // message_start: {"type":"message_start","message":{"...","usage":{"input_tokens":N}}, ...}
     // content_block_start: {"type":"content_block_start","index":0,...}
     // content_block_delta: {"type":"content_block_delta","delta":{"type":"text_delta","text":"..."}}
+    //                    or: {"type":"content_block_delta","delta":{"type":"input_json_delta","partial_json":"..."}}
+    //                    (for tool_use, input_json_delta carries the partial JSON arguments)
     // message_delta: {"type":"message_delta","delta":{"stop_reason":"..."},"usage":{"output_tokens":N}}
     // message_stop: {"type":"message_stop"}
     nlohmann::json ReconstructFromStreamedChunks(const std::string& sse_raw) const override {
         std::string accumulated_content;
+        std::string accumulated_input_json;
         std::string finish_reason;
         int64_t input_tokens = 0;
         int64_t output_tokens = 0;
+        bool has_tool_use = false;
 
         std::istringstream stream(sse_raw);
         std::string line;
@@ -201,9 +236,22 @@ protected:
                     }
                 }
 
-                // content_block_delta: accumulate text
-                if (current_event == "content_block_delta" && chunk.contains("delta") && chunk["delta"].contains("text") && chunk["delta"]["text"].is_string()) {
-                    accumulated_content += chunk["delta"]["text"].get<std::string>();
+                // content_block_delta: accumulate text or tool input JSON
+                if (current_event == "content_block_delta" && chunk.contains("delta")) {
+                    auto& delta = chunk["delta"];
+                    // Text content from text_delta
+                    if (delta.contains("text") && delta["text"].is_string()) {
+                        accumulated_content += delta["text"].get<std::string>();
+                    }
+                    // Thinking content from thinking_delta (skip - it's reasoning, not the answer)
+                    if (delta.contains("type") && delta["type"] == "thinking_delta") {
+                        // Intentionally skip thinking content
+                    }
+                    // Tool call arguments from input_json_delta (streaming tool_use)
+                    if (delta.contains("type") && delta["type"] == "input_json_delta" && delta.contains("partial_json")) {
+                        has_tool_use = true;
+                        accumulated_input_json += delta["partial_json"].get<std::string>();
+                    }
                 }
 
                 // message_delta: get stop_reason and output_tokens
@@ -222,14 +270,42 @@ protected:
             }
         }
 
-        if (accumulated_content.empty()) {
+        if (accumulated_content.empty() && accumulated_input_json.empty()) {
             return nlohmann::json();
         }
 
-        // Reconstruct in the same shape Anthropic's non-streaming response would have
-        // (content array with text blocks that contain JSON strings)
-        nlohmann::json reconstructed = {
-                {"content", nlohmann::json::array({{"type", "text"}, {"text", accumulated_content}})}};
+        nlohmann::json reconstructed;
+
+        if (has_tool_use && !accumulated_input_json.empty()) {
+            // Reconstruct tool_use response for streaming structured output
+            // Non-streaming format: {"content": [{"type": "tool_use", "id": "...", "name": "flock_response", "input": {...}}]}
+            try {
+                auto input_json = nlohmann::json::parse(accumulated_input_json);
+                if (input_json.contains("items") && !input_json["items"].is_array()) {
+                    input_json["items"] = nlohmann::json::array({input_json["items"]});
+                }
+                nlohmann::json tool_block;
+                tool_block["type"] = "tool_use";
+                tool_block["id"] = "call_0";
+                tool_block["name"] = "flock_response";
+                tool_block["input"] = input_json;
+                reconstructed["content"] = nlohmann::json::array({tool_block});
+            } catch (...) {
+                // If input JSON parsing fails, fall back to text
+                nlohmann::json text_block;
+                text_block["type"] = "text";
+                text_block["text"] = accumulated_input_json;
+                reconstructed["content"] = nlohmann::json::array({text_block});
+            }
+        } else {
+            // Reconstruct in the same shape Anthropic's non-streaming response would have
+            // (content array with text blocks that contain JSON strings)
+            nlohmann::json text_block;
+            text_block["type"] = "text";
+            text_block["text"] = accumulated_content;
+            reconstructed["content"] = nlohmann::json::array({text_block});
+        }
+
         if (!finish_reason.empty()) reconstructed["stop_reason"] = finish_reason;
 
         if (input_tokens > 0 || output_tokens > 0) {

--- a/src/include/flock/model_manager/providers/handlers/anthropic.hpp
+++ b/src/include/flock/model_manager/providers/handlers/anthropic.hpp
@@ -6,6 +6,7 @@
 #include <cstdlib>
 #include <iostream>
 #include <nlohmann/json.hpp>
+#include <sstream>
 #include <stdexcept>
 #include <string>
 
@@ -151,6 +152,93 @@ protected:
             }
         }
         return {input_tokens, output_tokens};
+    }
+
+    // Anthropic streaming format uses event types:
+    // message_start: {"type":"message_start","message":{"...","usage":{"input_tokens":N}}, ...}
+    // content_block_start: {"type":"content_block_start","index":0,...}
+    // content_block_delta: {"type":"content_block_delta","delta":{"type":"text_delta","text":"..."}}
+    // message_delta: {"type":"message_delta","delta":{"stop_reason":"..."},"usage":{"output_tokens":N}}
+    // message_stop: {"type":"message_stop"}
+    nlohmann::json ReconstructFromStreamedChunks(const std::string& sse_raw) const override {
+        std::string accumulated_content;
+        std::string finish_reason;
+        int64_t input_tokens = 0;
+        int64_t output_tokens = 0;
+
+        std::istringstream stream(sse_raw);
+        std::string line;
+        std::string current_event;
+
+        while (std::getline(stream, line)) {
+            // Trim
+            while (!line.empty() && (line.front() == ' ' || line.front() == '\t')) line.erase(line.begin());
+            while (!line.empty() && (line.back() == ' ' || line.back() == '\t' || line.back() == '\r')) line.pop_back();
+
+            if (line.rfind("event: ", 0) == 0) {
+                current_event = line.substr(7);
+                continue;
+            }
+            if (line.rfind("data: ", 0) == 0) {
+                std::string json_str = line.substr(6);
+                if (json_str.empty() || json_str[0] != '{') continue;
+
+                nlohmann::json chunk;
+                try {
+                    chunk = nlohmann::json::parse(json_str);
+                } catch (...) { continue; }
+
+                if (chunk.contains("error")) return nlohmann::json();
+
+                // message_start: get input_tokens
+                if (current_event == "message_start" && chunk.contains("message")) {
+                    const auto& msg = chunk["message"];
+                    if (msg.contains("usage") && msg["usage"].is_object()) {
+                        const auto& usage = msg["usage"];
+                        if (usage.contains("input_tokens") && usage["input_tokens"].is_number()) {
+                            input_tokens = usage["input_tokens"].get<int64_t>();
+                        }
+                    }
+                }
+
+                // content_block_delta: accumulate text
+                if (current_event == "content_block_delta" && chunk.contains("delta") && chunk["delta"].contains("text") && chunk["delta"]["text"].is_string()) {
+                    accumulated_content += chunk["delta"]["text"].get<std::string>();
+                }
+
+                // message_delta: get stop_reason and output_tokens
+                if (current_event == "message_delta") {
+                    if (chunk.contains("delta") && chunk["delta"].contains("stop_reason")) {
+                        auto& sr = chunk["delta"]["stop_reason"];
+                        if (sr.is_string()) finish_reason = sr.get<std::string>();
+                    }
+                    if (chunk.contains("usage") && chunk["usage"].is_object()) {
+                        const auto& usage = chunk["usage"];
+                        if (usage.contains("output_tokens") && usage["output_tokens"].is_number()) {
+                            output_tokens = usage["output_tokens"].get<int64_t>();
+                        }
+                    }
+                }
+            }
+        }
+
+        if (accumulated_content.empty()) {
+            return nlohmann::json();
+        }
+
+        // Reconstruct in the same shape Anthropic's non-streaming response would have
+        // (content array with text blocks that contain JSON strings)
+        nlohmann::json reconstructed = {
+                {"content", nlohmann::json::array({{"type", "text"}, {"text", accumulated_content}})}};
+        if (!finish_reason.empty()) reconstructed["stop_reason"] = finish_reason;
+
+        if (input_tokens > 0 || output_tokens > 0) {
+            reconstructed["usage"] = {
+                    {"input_tokens", input_tokens},
+                    {"output_tokens", output_tokens}};
+        }
+
+        return reconstructed;
     }
 };
 

--- a/src/include/flock/model_manager/providers/handlers/azure.hpp
+++ b/src/include/flock/model_manager/providers/handlers/azure.hpp
@@ -1,4 +1,5 @@
 #include "flock/model_manager/providers/handlers/base_handler.hpp"
+#include <sstream>
 
 namespace flock {
 
@@ -103,6 +104,12 @@ protected:
             return response["text"].get<std::string>();
         }
         return "";
+    }
+
+    // Azure uses the same streaming format as OpenAI
+    // Azure uses the same OpenAI-compatible streaming format as OpenAI.
+    nlohmann::json ReconstructFromStreamedChunks(const std::string& sse_raw) const override {
+        return ReconstructOpenAIStreamingChunks(sse_raw);
     }
 
 

--- a/src/include/flock/model_manager/providers/handlers/base_handler.hpp
+++ b/src/include/flock/model_manager/providers/handlers/base_handler.hpp
@@ -89,6 +89,20 @@ protected:
 
         EnsureUsageLimitNotExceeded();
 
+        // Detect streaming: check if the first completion request has "stream": true
+        bool is_streamed = false;
+        if (request_type == RequestType::Completion) {
+            for (const auto& json: jsons) {
+                if (json.contains("stream") && json["stream"].is_boolean() && json["stream"].get<bool>()) {
+                    is_streamed = true;
+                    break;
+                }
+            }
+        }
+        if (is_streamed) {
+            return ExecuteBatchStreamed(jsons, contentType);
+        }
+
 #ifdef __EMSCRIPTEN__
         // WASM: Process requests sequentially using emscripten fetch
         std::vector<nlohmann::json> results(jsons.size());
@@ -296,6 +310,137 @@ protected:
 #endif
     }
 
+    // Streaming execution path for SSE responses
+    std::vector<nlohmann::json> ExecuteBatchStreamed(const std::vector<nlohmann::json>& jsons, const std::string& contentType = "application/json") {
+#ifdef __EMSCRIPTEN__
+        // WASM: Process streaming requests sequentially
+        std::vector<nlohmann::json> results(jsons.size());
+        for (size_t i = 0; i < jsons.size(); ++i) {
+            prepareSessionForRequest(getCompletionUrl());
+            setParameters(jsons[i].dump(), contentType);
+            auto response = postRequest(contentType);
+
+            if (response.is_error || response.text.empty()) {
+                trigger_error(response.error_message);
+            } else {
+                auto reconstructed = ReconstructFromStreamedChunks(response.text);
+                if (reconstructed.is_null()) {
+                    trigger_error("Failed to reconstruct streaming response");
+                } else {
+                    try {
+                        checkResponse(reconstructed, RequestType::Completion);
+                        results[i] = ExtractOutput(reconstructed, RequestType::Completion);
+                    } catch (const TokenLimitExceededError&) {
+                        results[i] = TokenLimitExceededMarker();
+                    } catch (const std::exception& e) {
+                        trigger_error(std::string("Response processing error: ") + e.what());
+                    }
+                }
+            }
+        }
+        return results;
+#else
+        // Native: Use curl multi-handle with SSE accumulation
+        struct CurlRequestData {
+            std::string response;
+            CURL* easy = nullptr;
+            std::string payload;
+        };
+        std::vector<CurlRequestData> requests(jsons.size());
+        CURLM* multi_handle = curl_multi_init();
+        std::string url = getCompletionUrl();
+
+        for (size_t i = 0; i < jsons.size(); ++i) {
+            requests[i].easy = curl_easy_init();
+            curl_easy_setopt(requests[i].easy, CURLOPT_URL, url.c_str());
+            requests[i].payload = jsons[i].dump();
+            struct curl_slist* headers = nullptr;
+            headers = curl_slist_append(headers, "Content-Type: application/json");
+            for (const auto& h: getExtraHeaders()) {
+                headers = curl_slist_append(headers, h.c_str());
+            }
+            headers = curl_slist_append(headers, "Accept: text/event-stream");
+            curl_easy_setopt(requests[i].easy, CURLOPT_HTTPHEADER, headers);
+            curl_easy_setopt(requests[i].easy, CURLOPT_POST, 1L);
+            curl_easy_setopt(requests[i].easy, CURLOPT_POSTFIELDS, requests[i].payload.c_str());
+
+            curl_easy_setopt(
+                    requests[i].easy, CURLOPT_WRITEFUNCTION, +[](char* ptr, size_t size, size_t nmemb, void* userdata) -> size_t {
+                        std::string* resp = static_cast<std::string*>(userdata);
+                        resp->append(ptr, size * nmemb);
+                        return size * nmemb;
+                    });
+            curl_easy_setopt(requests[i].easy, CURLOPT_WRITEDATA, &requests[i].response);
+            curl_easy_setopt(requests[i].easy, CURLOPT_TIMEOUT, 600L);
+
+            curl_multi_add_handle(multi_handle, requests[i].easy);
+        }
+
+        auto api_start = std::chrono::high_resolution_clock::now();
+        int still_running = 0;
+        curl_multi_perform(multi_handle, &still_running);
+        while (still_running) {
+            int numfds;
+            curl_multi_wait(multi_handle, NULL, 0, 1000, &numfds);
+            curl_multi_perform(multi_handle, &still_running);
+        }
+        auto api_end = std::chrono::high_resolution_clock::now();
+        double api_duration_ms = std::chrono::duration<double, std::milli>(api_end - api_start).count();
+
+        int64_t batch_input_tokens = 0;
+        int64_t batch_output_tokens = 0;
+        std::vector<nlohmann::json> results(jsons.size());
+
+        for (size_t i = 0; i < requests.size(); ++i) {
+            long http_code = 0;
+            curl_easy_getinfo(requests[i].easy, CURLINFO_RESPONSE_CODE, &http_code);
+
+            if (requests[i].response.empty()) {
+                trigger_error("Empty streaming response from provider (HTTP " + std::to_string(http_code) + ", URL: " + url + ")");
+            } else {
+                auto reconstructed = ReconstructFromStreamedChunks(requests[i].response);
+                if (reconstructed.is_null()) {
+                    trigger_error("Failed to parse streaming response (HTTP " + std::to_string(http_code) + ")");
+                } else {
+                    try {
+                        checkResponse(reconstructed, RequestType::Completion);
+                        auto [input_tokens, output_tokens] = ExtractTokenUsage(reconstructed);
+                        batch_input_tokens += input_tokens;
+                        batch_output_tokens += output_tokens;
+                        try {
+                            results[i] = ExtractOutput(reconstructed, RequestType::Completion);
+                        } catch (const std::exception& e) {
+                            std::string msg = e.what();
+                            if (msg.rfind("[ModelProvider]", 0) == 0) {
+                                throw;
+                            }
+                            trigger_error(std::string("Output extraction error: ") + msg);
+                        }
+                    } catch (const TokenLimitExceededError&) {
+                        results[i] = TokenLimitExceededMarker();
+                    } catch (const std::exception& e) {
+                        std::string msg = e.what();
+                        if (msg.rfind("[ModelProvider]", 0) == 0) {
+                            throw;
+                        }
+                        trigger_error(std::string("Streaming response processing error: ") + msg);
+                    }
+                }
+            }
+            curl_easy_cleanup(requests[i].easy);
+        }
+
+        MetricsManager::UpdateTokens(batch_input_tokens, batch_output_tokens);
+        MetricsManager::AddApiDuration(api_duration_ms);
+        for (size_t i = 0; i < jsons.size(); ++i) {
+            MetricsManager::IncrementApiCalls();
+        }
+
+        curl_multi_cleanup(multi_handle);
+        return results;
+#endif
+    }
+
     virtual void setParameters(const std::string& data, const std::string& contentType = "") = 0;
     virtual auto postRequest(const std::string& contentType) -> decltype(((Session*) nullptr)->postPrepare(contentType)) = 0;
 
@@ -318,6 +463,91 @@ protected:
     virtual nlohmann::json ExtractCompletionOutput(const nlohmann::json&) const { return {}; }
     virtual nlohmann::json ExtractEmbeddingVector(const nlohmann::json&) const { return {}; }
     virtual nlohmann::json ExtractTranscriptionOutput(const nlohmann::json&) const = 0;
+
+    // Reconstruct a full completion JSON from raw SSE streaming text.
+    // Returns nlohmann::json() (null) on failure on failure.
+    virtual nlohmann::json ReconstructFromStreamedChunks(const std::string& sse_raw) const {
+        // Default: no streaming support
+        (void) sse_raw;
+        return nlohmann::json();
+    }
+
+    // Shared utility: Reconstruct OpenAI-compatible completion JSON from SSE chunks.
+    // Handles the standard format with content in delta.content.
+    // Returns the reconstructed JSON in OpenAI non-streaming format shape.
+    static nlohmann::json ReconstructOpenAIStreamingChunks(const std::string& sse_raw) {
+        std::string accumulated_content;
+        std::string finish_reason;
+        nlohmann::json usage;
+
+        std::istringstream stream(sse_raw);
+        std::string line;
+
+        while (std::getline(stream, line)) {
+            // Trim whitespace
+            while (!line.empty() && (line.front() == ' ' || line.front() == '\t')) line.erase(line.begin());
+            while (!line.empty() && (line.back() == ' ' || line.back() == '\t' || line.back() == '\r')) line.pop_back();
+
+            if (line.rfind("data: ", 0) == 0) {
+                std::string json_str = line.substr(6);
+                if (json_str.empty() || json_str == "[DONE]") continue;
+                if (json_str[0] != '{' && json_str[0] != '[') continue;
+
+                nlohmann::json chunk;
+                try {
+                    chunk = nlohmann::json::parse(json_str);
+                } catch (...) {
+                    continue;
+                }
+
+                // Accumulate delta content from choices.
+                // Standard OpenAI: content is in delta.content.
+                // vLLM: may send content="" on first chunk, content with answer on last chunk.
+                // Reasoning (thinking) is always in delta.reasoning and should NOT be mixed into the final answer.
+                if (chunk.contains("choices") && chunk["choices"].is_array()) {
+                    for (const auto& choice: chunk["choices"]) {
+                        if (choice.contains("delta") && choice["delta"].is_object()) {
+                            auto& delta = choice["delta"];
+                            if (delta.contains("content") && delta["content"].is_string()) {
+                                std::string c = delta["content"].get<std::string>();
+                                if (!c.empty()) {
+                                    accumulated_content += c;
+                                }
+                            }
+                            // Note: we intentionally DO NOT accumulate delta.reasoning.
+                            // Reasoning is the model's thinking process and should be excluded from the final answer.
+                        }
+                        // Capture finish_reason from the last chunk that has it
+                        if (choice.contains("finish_reason") && choice["finish_reason"].is_string()) {
+                            finish_reason = choice["finish_reason"].get<std::string>();
+                        }
+                    }
+                }
+
+                // Capture usage - usually in the last chunk (can be at top level)
+                if (chunk.contains("usage")) {
+                    usage = chunk["usage"];
+                }
+            }
+        }
+
+        // Build the reconstructed JSON in the same shape as non-streaming response
+        nlohmann::json message;
+        message["role"] = "assistant";
+        message["content"] = accumulated_content;
+        nlohmann::json choice;
+        choice["index"] = 0;
+        choice["message"] = message;
+        if (!finish_reason.empty()) choice["finish_reason"] = finish_reason;
+        nlohmann::json reconstructed = {
+                {"choices", nlohmann::json::array({choice})}};
+
+        if (!usage.empty()) {
+            reconstructed["usage"] = usage;
+        }
+
+        return reconstructed;
+    }
 
     // Unified extraction method - delegates to specific Extract* methods based on request type
     nlohmann::json ExtractOutput(const nlohmann::json& parsed, RequestType request_type) const {

--- a/src/include/flock/model_manager/providers/handlers/base_handler.hpp
+++ b/src/include/flock/model_manager/providers/handlers/base_handler.hpp
@@ -123,11 +123,7 @@ protected:
                     checkResponse(parsed, request_type);
                     if (!is_transcription) {
                         auto [input_tokens, output_tokens] = ExtractTokenUsage(parsed);
-                        try {
-                            RecordTokenUsage(input_tokens, output_tokens);
-                        } catch (const UsageLimitExceededError&) {
-                            // Silently ignore — next EnsureUsageLimitNotExceeded() will block
-                        }
+                        RecordTokenUsageWithSoftCap(input_tokens, output_tokens);
                     }
                     ExtractOutputWithErrorHandling(parsed, request_type, results[i]);
                 } catch (const TokenLimitExceededError&) {
@@ -278,11 +274,7 @@ protected:
                         auto [input_tokens, output_tokens] = ExtractTokenUsage(parsed);
                         batch_input_tokens += input_tokens;
                         batch_output_tokens += output_tokens;
-                        try {
-                            RecordTokenUsage(input_tokens, output_tokens);
-                        } catch (const UsageLimitExceededError&) {
-                            // Silently ignore — next EnsureUsageLimitNotExceeded() will block
-                        }
+                        RecordTokenUsageWithSoftCap(input_tokens, output_tokens);
                     }
 
                     ExtractOutputWithErrorHandling(parsed, request_type, results[i]);
@@ -338,11 +330,7 @@ protected:
                     try {
                         checkResponse(reconstructed, RequestType::Completion);
                         auto [input_tokens, output_tokens] = ExtractTokenUsage(reconstructed);
-                        try {
-                            RecordTokenUsage(input_tokens, output_tokens);
-                        } catch (const UsageLimitExceededError&) {
-                            // Silently ignore — next EnsureUsageLimitNotExceeded() will block
-                        }
+                        RecordTokenUsageWithSoftCap(input_tokens, output_tokens);
                         results[i] = ExtractOutput(reconstructed, RequestType::Completion);
                     } catch (const TokenLimitExceededError&) {
                         results[i] = TokenLimitExceededMarker();
@@ -423,11 +411,7 @@ protected:
                         auto [input_tokens, output_tokens] = ExtractTokenUsage(reconstructed);
                         batch_input_tokens += input_tokens;
                         batch_output_tokens += output_tokens;
-                        try {
-                            RecordTokenUsage(input_tokens, output_tokens);
-                        } catch (const UsageLimitExceededError&) {
-                            // Silently ignore — next EnsureUsageLimitNotExceeded() will block
-                        }
+                        RecordTokenUsageWithSoftCap(input_tokens, output_tokens);
                         try {
                             results[i] = ExtractOutput(reconstructed, RequestType::Completion);
                         } catch (const std::exception& e) {
@@ -585,6 +569,14 @@ protected:
     void RecordTokenUsage(int64_t prompt_tokens, int64_t completion_tokens) {
         if (_usage_limit.has_value() && _usage_limiter != nullptr) {
             _usage_limiter->RecordUsage(prompt_tokens, completion_tokens, _usage_limit);
+        }
+    }
+
+    void RecordTokenUsageWithSoftCap(int64_t prompt_tokens, int64_t completion_tokens) {
+        try {
+            RecordTokenUsage(prompt_tokens, completion_tokens);
+        } catch (const UsageLimitExceededError&) {
+            // Silently ignore — next EnsureUsageLimitNotExceeded() will block
         }
     }
 

--- a/src/include/flock/model_manager/providers/handlers/base_handler.hpp
+++ b/src/include/flock/model_manager/providers/handlers/base_handler.hpp
@@ -109,7 +109,6 @@ protected:
         bool is_completion = (request_type == RequestType::Completion);
         bool is_transcription = (request_type == RequestType::Transcription);
         auto url = is_completion ? getCompletionUrl() : getEmbedUrl();
-        bool usage_limit_reached = false;
 
         for (size_t i = 0; i < jsons.size(); ++i) {
             EnsureUsageLimitNotExceeded();
@@ -124,7 +123,11 @@ protected:
                     checkResponse(parsed, request_type);
                     if (!is_transcription) {
                         auto [input_tokens, output_tokens] = ExtractTokenUsage(parsed);
-                        RecordTokenUsageWithSoftCap(input_tokens, output_tokens, usage_limit_reached);
+                        try {
+                            RecordTokenUsage(input_tokens, output_tokens);
+                        } catch (const UsageLimitExceededError&) {
+                            // Silently ignore — next EnsureUsageLimitNotExceeded() will block
+                        }
                     }
                     ExtractOutputWithErrorHandling(parsed, request_type, results[i]);
                 } catch (const TokenLimitExceededError&) {
@@ -254,7 +257,6 @@ protected:
         int64_t batch_output_tokens = 0;
 
         std::vector<nlohmann::json> results(jsons.size());
-        bool usage_limit_reached = false;
         for (size_t i = 0; i < requests.size(); ++i) {
             // Clean up temp files for transcriptions
             if (is_transcription && requests[i].is_temp_file && !requests[i].temp_file_path.empty()) {
@@ -276,7 +278,11 @@ protected:
                         auto [input_tokens, output_tokens] = ExtractTokenUsage(parsed);
                         batch_input_tokens += input_tokens;
                         batch_output_tokens += output_tokens;
-                        RecordTokenUsageWithSoftCap(input_tokens, output_tokens, usage_limit_reached);
+                        try {
+                            RecordTokenUsage(input_tokens, output_tokens);
+                        } catch (const UsageLimitExceededError&) {
+                            // Silently ignore — next EnsureUsageLimitNotExceeded() will block
+                        }
                     }
 
                     ExtractOutputWithErrorHandling(parsed, request_type, results[i]);
@@ -316,6 +322,8 @@ protected:
         // WASM: Process streaming requests sequentially
         std::vector<nlohmann::json> results(jsons.size());
         for (size_t i = 0; i < jsons.size(); ++i) {
+            EnsureUsageLimitNotExceeded();
+
             prepareSessionForRequest(getCompletionUrl());
             setParameters(jsons[i].dump(), contentType);
             auto response = postRequest(contentType);
@@ -329,6 +337,12 @@ protected:
                 } else {
                     try {
                         checkResponse(reconstructed, RequestType::Completion);
+                        auto [input_tokens, output_tokens] = ExtractTokenUsage(reconstructed);
+                        try {
+                            RecordTokenUsage(input_tokens, output_tokens);
+                        } catch (const UsageLimitExceededError&) {
+                            // Silently ignore — next EnsureUsageLimitNotExceeded() will block
+                        }
                         results[i] = ExtractOutput(reconstructed, RequestType::Completion);
                     } catch (const TokenLimitExceededError&) {
                         results[i] = TokenLimitExceededMarker();
@@ -392,6 +406,8 @@ protected:
         std::vector<nlohmann::json> results(jsons.size());
 
         for (size_t i = 0; i < requests.size(); ++i) {
+            EnsureUsageLimitNotExceeded();
+
             long http_code = 0;
             curl_easy_getinfo(requests[i].easy, CURLINFO_RESPONSE_CODE, &http_code);
 
@@ -407,6 +423,11 @@ protected:
                         auto [input_tokens, output_tokens] = ExtractTokenUsage(reconstructed);
                         batch_input_tokens += input_tokens;
                         batch_output_tokens += output_tokens;
+                        try {
+                            RecordTokenUsage(input_tokens, output_tokens);
+                        } catch (const UsageLimitExceededError&) {
+                            // Silently ignore — next EnsureUsageLimitNotExceeded() will block
+                        }
                         try {
                             results[i] = ExtractOutput(reconstructed, RequestType::Completion);
                         } catch (const std::exception& e) {
@@ -570,17 +591,6 @@ protected:
     void EnsureUsageLimitNotExceeded() const {
         if (_usage_limit.has_value() && _usage_limiter != nullptr) {
             _usage_limiter->ThrowIfLimitExceeded(*_usage_limit);
-        }
-    }
-
-    void RecordTokenUsageWithSoftCap(int64_t prompt_tokens, int64_t completion_tokens, bool& usage_limit_reached) {
-        if (usage_limit_reached) {
-            return;
-        }
-        try {
-            RecordTokenUsage(prompt_tokens, completion_tokens);
-        } catch (const UsageLimitExceededError&) {
-            usage_limit_reached = true;
         }
     }
 

--- a/src/include/flock/model_manager/providers/handlers/handler.hpp
+++ b/src/include/flock/model_manager/providers/handlers/handler.hpp
@@ -9,7 +9,8 @@ class IModelProviderHandler {
 public:
     enum class RequestType { Completion,
                              Embedding,
-                             Transcription };
+                             Transcription,
+                             CompletionStreamed };
 
     virtual ~IModelProviderHandler() = default;
     // AddRequest: type distinguishes between completion, embedding, and transcription (default: Completion)

--- a/src/include/flock/model_manager/providers/handlers/ollama.hpp
+++ b/src/include/flock/model_manager/providers/handlers/ollama.hpp
@@ -4,6 +4,7 @@
 #include "session.hpp"
 #include <cstdlib>
 #include <curl/curl.h>
+#include <sstream>
 
 namespace flock {
 
@@ -27,6 +28,10 @@ protected:
     std::string getCompletionUrl() const override { return _url + "/api/chat"; }
     std::string getEmbedUrl() const override { return _url + "/api/embed"; }
     std::string getTranscriptionUrl() const override { return ""; }
+    std::vector<std::string> getExtraHeaders() const override {
+        // Add Connection: close to prevent curl_multi_wait from hanging on keepalive
+        return {"Connection: close"};
+    }
     void prepareSessionForRequest(const std::string& url) override { _session.setUrl(url); }
     void setParameters(const std::string& data, const std::string& contentType = "") override {
         if (contentType != "multipart/form-data") {
@@ -117,6 +122,73 @@ protected:
 
     nlohmann::json ExtractTranscriptionOutput(const nlohmann::json& response) const override {
         throw std::runtime_error("Audio transcription is not supported for Ollama provider, use Azure or OpenAI instead.");
+    }
+
+    // Ollama streaming format (native /api/chat): plain JSON lines, not SSE.
+    // Each line is a complete JSON object: {"message":{"content":"..."},"done":false}
+    nlohmann::json ReconstructFromStreamedChunks(const std::string& sse_raw) const override {
+        std::string accumulated_content;
+        std::string finish_reason;
+        int64_t input_tokens = 0;
+        int64_t output_tokens = 0;
+        bool done = false;
+
+        std::istringstream stream(sse_raw);
+        std::string line;
+
+        while (std::getline(stream, line)) {
+            while (!line.empty() && (line.front() == ' ' || line.front() == '\t')) line.erase(line.begin());
+            while (!line.empty() && (line.back() == ' ' || line.back() == '\t' || line.back() == '\r')) line.pop_back();
+
+            if (line.empty() || line[0] != '{') continue;
+
+            nlohmann::json chunk;
+            try {
+                chunk = nlohmann::json::parse(line);
+            } catch (...) { continue; }
+
+            if (chunk.contains("message") && chunk["message"].is_object()) {
+                // When think=true, the model outputs to BOTH fields:
+                // - thinking: raw trace (reasoning + answer)
+                // - content: clean answer (only at end)
+                // Since content always exists (even empty), first if matches during thinking,
+                // and we only accumulate the clean content at the end.
+                if (chunk["message"].contains("content") && chunk["message"]["content"].is_string()) {
+                    accumulated_content += chunk["message"]["content"].get<std::string>();
+                }
+            }
+
+            if (chunk.contains("done")) done = chunk["done"].get<bool>();
+
+            // Capture finish_reason and usage from the last chunk
+            if (chunk.contains("error")) {
+                return nlohmann::json();
+            }
+            if (done) {
+                if (chunk.contains("done_reason")) {
+                    auto& dr = chunk["done_reason"];
+                    if (dr.is_string()) finish_reason = dr.get<std::string>();
+                }
+                if (chunk.contains("prompt_eval_count")) input_tokens = chunk["prompt_eval_count"].get<int64_t>();
+                if (chunk.contains("eval_count")) output_tokens = chunk["eval_count"].get<int64_t>();
+            }
+        }
+
+        if (accumulated_content.empty()) {
+            return nlohmann::json();
+        }
+
+        nlohmann::json reconstructed;
+        reconstructed["message"]["content"] = accumulated_content;
+        reconstructed["message"]["role"] = "assistant";
+        if (!finish_reason.empty()) {
+            reconstructed["done_reason"] = finish_reason;
+        }
+        reconstructed["done"] = true;
+        if (input_tokens > 0) reconstructed["prompt_eval_count"] = input_tokens;
+        if (output_tokens > 0) reconstructed["eval_count"] = output_tokens;
+
+        return reconstructed;
     }
 
 

--- a/src/include/flock/model_manager/providers/handlers/openai.hpp
+++ b/src/include/flock/model_manager/providers/handlers/openai.hpp
@@ -3,6 +3,7 @@
 #include "flock/model_manager/providers/handlers/base_handler.hpp"
 #include "session.hpp"
 #include <cstdlib>
+#include <sstream>
 
 namespace flock {
 
@@ -82,6 +83,7 @@ protected:
             }
         }
     }
+
     nlohmann::json ExtractCompletionOutput(const nlohmann::json& response) const override {
         if (response.contains("choices") && response["choices"].is_array() && !response["choices"].empty()) {
             const auto& choice = response["choices"][0];
@@ -125,6 +127,11 @@ protected:
             return response["text"].get<std::string>();
         }
         return "";
+    }
+
+    // Reconstruct full completion JSON from SSE streaming chunks (delegates to shared utility).
+    nlohmann::json ReconstructFromStreamedChunks(const std::string& sse_raw) const override {
+        return ReconstructOpenAIStreamingChunks(sse_raw);
     }
 };
 

--- a/src/model_manager/providers/adapters/anthropic.cpp
+++ b/src/model_manager/providers/adapters/anthropic.cpp
@@ -59,7 +59,8 @@ void AnthropicProvider::AddCompletionRequest(const std::string& prompt, const in
     }
 
     nlohmann::json request_payload = {{"model", model_details_.model},
-                                      {"messages", {{{"role", "user"}, {"content", message_content}}}}};
+                                      {"messages", {{{"role", "user"}, {"content", message_content}}}},
+                                      {"stream", true}};
 
     if (!model_details_.model_parameters.empty()) {
         request_payload.update(model_details_.model_parameters);

--- a/src/model_manager/providers/adapters/azure.cpp
+++ b/src/model_manager/providers/adapters/azure.cpp
@@ -65,7 +65,8 @@ void AzureProvider::AddCompletionRequest(const std::string& prompt, const int nu
     }
 
     nlohmann::json request_payload = {{"model", model_details_.model},
-                                      {"messages", {{{"role", "user"}, {"content", message_content}}}}};
+                                      {"messages", {{{"role", "user"}, {"content", message_content}}}},
+                                      {"stream", true}};
 
     if (!model_details_.model_parameters.empty()) {
         request_payload.update(model_details_.model_parameters);

--- a/src/model_manager/providers/adapters/ollama.cpp
+++ b/src/model_manager/providers/adapters/ollama.cpp
@@ -39,8 +39,7 @@ void OllamaProvider::AddCompletionRequest(const std::string& prompt, const int n
 
     nlohmann::json request_payload = {{"model", model_details_.model},
                                       {"messages", nlohmann::json::array({message})},
-                                      {"stream", true},
-                                      {"think", true}};
+                                      {"stream", true}};
 
     if (!model_details_.model_parameters.empty()) {
         request_payload.update(model_details_.model_parameters);

--- a/src/model_manager/providers/adapters/ollama.cpp
+++ b/src/model_manager/providers/adapters/ollama.cpp
@@ -39,7 +39,8 @@ void OllamaProvider::AddCompletionRequest(const std::string& prompt, const int n
 
     nlohmann::json request_payload = {{"model", model_details_.model},
                                       {"messages", nlohmann::json::array({message})},
-                                      {"stream", false}};
+                                      {"stream", true},
+                                      {"think", true}};
 
     if (!model_details_.model_parameters.empty()) {
         request_payload.update(model_details_.model_parameters);

--- a/src/model_manager/providers/adapters/openai.cpp
+++ b/src/model_manager/providers/adapters/openai.cpp
@@ -65,7 +65,8 @@ void OpenAIProvider::AddCompletionRequest(const std::string& prompt, const int n
     }
 
     nlohmann::json request_payload = {{"model", model_details_.model},
-                                      {"messages", {{{"role", "user"}, {"content", message_content}}}}};
+                                      {"messages", {{{"role", "user"}, {"content", message_content}}}},
+                                      {"stream", true}};
 
     if (!model_details_.model_parameters.empty()) {
         request_payload.update(model_details_.model_parameters);

--- a/src/secret_manager/secret_manager.cpp
+++ b/src/secret_manager/secret_manager.cpp
@@ -19,7 +19,7 @@ SecretDetails get_ollama_secret_details() {
 }
 
 SecretDetails get_anthropic_secret_details() {
-    return {"anthropic", "flock", "anthropic://", {"api_key", "api_version"}, {"api_key"}, {"api_key"}};
+    return {"anthropic", "flock", "anthropic://", {"api_key", "api_version", "api_url"}, {"api_key"}, {"api_key"}};
 }
 
 std::vector<SecretDetails> get_secret_details_list() {


### PR DESCRIPTION
Use streaming by default on all providers to avoid timeouts.
Streaming can still be disabled by setting `stream: false` in the model parameters

All tests pass locally except the ones that were already failing on `dev`

close https://github.com/dais-polymtl/flock/issues/285